### PR TITLE
Fix bugs in TorManager

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,2 @@
+[*.{kt, kts}]
+max_line_length = 118

--- a/app/src/main/java/org/onionshare/android/OnionShareApp.kt
+++ b/app/src/main/java/org/onionshare/android/OnionShareApp.kt
@@ -1,6 +1,8 @@
 package org.onionshare.android
 
 import android.app.Application
+import android.content.Intent.FLAG_GRANT_READ_URI_PERMISSION
+import android.content.UriPermission
 import android.os.StrictMode
 import android.os.StrictMode.ThreadPolicy
 import android.os.StrictMode.VmPolicy
@@ -13,6 +15,18 @@ class OnionShareApp @Inject constructor() : Application() {
     override fun onCreate() {
         if (BuildConfig.DEBUG) enableStrictMode()
         super.onCreate()
+        releaseUriPermissions()
+    }
+
+    /**
+     * There's a limit to how many persistable [UriPermission]s we can hold.
+     * At each app start, we release the ones that we may still hold from last time.
+     */
+    private fun releaseUriPermissions() {
+        val contentResolver = applicationContext.contentResolver
+        contentResolver.persistedUriPermissions.forEach { uriPermission ->
+            contentResolver.releasePersistableUriPermission(uriPermission.uri, FLAG_GRANT_READ_URI_PERMISSION)
+        }
     }
 
     private fun enableStrictMode() {

--- a/app/src/main/java/org/onionshare/android/OnionShareApp.kt
+++ b/app/src/main/java/org/onionshare/android/OnionShareApp.kt
@@ -1,8 +1,11 @@
 package org.onionshare.android
 
+import android.app.ActivityManager
 import android.app.Application
 import android.content.Intent.FLAG_GRANT_READ_URI_PERMISSION
 import android.content.UriPermission
+import android.os.Build.VERSION.SDK_INT
+import android.os.Process
 import android.os.StrictMode
 import android.os.StrictMode.ThreadPolicy
 import android.os.StrictMode.VmPolicy
@@ -15,7 +18,18 @@ class OnionShareApp @Inject constructor() : Application() {
     override fun onCreate() {
         if (BuildConfig.DEBUG) enableStrictMode()
         super.onCreate()
-        releaseUriPermissions()
+        if (!isTorProcess()) releaseUriPermissions()
+    }
+
+    private fun isTorProcess(): Boolean {
+        val processName = if (SDK_INT >= 28) {
+            getProcessName()
+        } else {
+            val pid = Process.myPid()
+            val manager = getSystemService(ACTIVITY_SERVICE) as ActivityManager
+            manager.runningAppProcesses?.firstOrNull { it.pid == pid }?.processName ?: return false
+        }
+        return processName.endsWith(":tor")
     }
 
     /**

--- a/app/src/main/java/org/onionshare/android/OnionShareApp.kt
+++ b/app/src/main/java/org/onionshare/android/OnionShareApp.kt
@@ -1,8 +1,32 @@
 package org.onionshare.android
 
 import android.app.Application
+import android.os.StrictMode
+import android.os.StrictMode.ThreadPolicy
+import android.os.StrictMode.VmPolicy
 import dagger.hilt.android.HiltAndroidApp
 import javax.inject.Inject
 
 @HiltAndroidApp
-class OnionShareApp @Inject constructor() : Application()
+class OnionShareApp @Inject constructor() : Application() {
+
+    override fun onCreate() {
+        if (BuildConfig.DEBUG) enableStrictMode()
+        super.onCreate()
+    }
+
+    private fun enableStrictMode() {
+        val threadPolicy: ThreadPolicy.Builder = ThreadPolicy.Builder().apply {
+            detectAll()
+            penaltyLog()
+            penaltyFlashScreen()
+        }
+        val vmPolicy = VmPolicy.Builder().apply {
+            detectAll()
+            penaltyLog()
+        }
+        StrictMode.setThreadPolicy(threadPolicy.build())
+        StrictMode.setVmPolicy(vmPolicy.build())
+    }
+
+}

--- a/app/src/main/java/org/onionshare/android/ShareManager.kt
+++ b/app/src/main/java/org/onionshare/android/ShareManager.kt
@@ -51,7 +51,8 @@ class ShareManager @Inject constructor(
 
         // taking persistable permissions only works with OPEN_DOCUMENT, not GET_CONTENT
         if (takePermission) {
-            // take persistable Uri permission to prevent SecurityException in same cases/devices
+            // take persistable Uri permission to prevent SecurityException
+            // when activity got killed before we use the Uri
             val contentResolver = app.applicationContext.contentResolver
             uris.forEach { uri ->
                 contentResolver.takePersistableUriPermission(uri, FLAG_GRANT_READ_URI_PERMISSION)

--- a/app/src/main/java/org/onionshare/android/ShareManager.kt
+++ b/app/src/main/java/org/onionshare/android/ShareManager.kt
@@ -14,14 +14,16 @@ import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.takeWhile
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.onionshare.android.files.FileManager
-import org.onionshare.android.server.PORT
+import org.onionshare.android.files.FilesZipping
 import org.onionshare.android.server.SendFile
 import org.onionshare.android.server.SendPage
 import org.onionshare.android.server.WebserverManager
 import org.onionshare.android.tor.TorManager
+import org.onionshare.android.tor.TorState
 import org.onionshare.android.ui.ShareUiState
 import org.slf4j.LoggerFactory.getLogger
 import java.io.IOException
@@ -103,22 +105,38 @@ class ShareManager @Inject constructor(
             val files = shareState.value.files
             // call ensureActive() before any heavy work to ensure we don't continue when cancelled
             ensureActive()
-            _shareState.value = ShareUiState.Starting(files, shareState.value.totalSize)
+            _shareState.value = ShareUiState.Starting(files, shareState.value.totalSize, 0, 0)
             try {
                 // TODO we might want to look into parallelizing what happens below (async {} ?)
                 // When the current scope gets cancelled, the async routine gets cancelled as well
                 ensureActive()
-                val sendPage = getSendPage(files)
+                var sendPage: SendPage? = null
+                fileManager.zipFiles(files).collect { state ->
+                    ensureActive()
+                    _shareState.value = ShareUiState.Starting(files, shareState.value.totalSize, state.progress, 0)
+                    if (state.complete) sendPage = getSendPage(state)
+                }
+                val page = sendPage ?: error("SendPage was null")
                 ensureActive()
                 // start tor and onion service
-                val onionAddress = torManager.start(PORT)
+                torManager.start()
+                var onion: String? = null
+                torManager.state.takeWhile { it !is TorState.Started }.collect { state ->
+                    if (state is TorState.Starting) {
+                        _shareState.value =
+                            ShareUiState.Starting(files, shareState.value.totalSize, 100, state.progress)
+                        onion = state.onion
+                    }
+                }
+                _shareState.value = ShareUiState.Starting(files, shareState.value.totalSize, 100, 100)
+                val onionAddress = onion ?: error("onion was null")
                 val url = "http://$onionAddress"
                 LOG.error("OnionShare URL: $url") // TODO remove before release
                 val sharing = ShareUiState.Sharing(files, shareState.value.totalSize, url)
                 // TODO properly manage tor and webserver state together
                 ensureActive()
                 // collecting from StateFlow will only return when coroutine gets cancelled
-                webserverManager.start(sendPage).collect {
+                webserverManager.start(page).collect {
                     onWebserverStateChanged(it, sharing)
                 }
             } catch (e: IOException) {
@@ -131,16 +149,15 @@ class ShareManager @Inject constructor(
     }
 
     @Throws(IOException::class)
-    private suspend fun getSendPage(files: List<SendFile>): SendPage {
-        val filesReady = fileManager.zipFiles(files)
-        val fileSize = filesReady.zip.length()
+    private fun getSendPage(filesZipping: FilesZipping): SendPage {
+        val fileSize = filesZipping.zip.length()
         return SendPage(
             fileName = "download.zip",
             fileSize = fileSize.toString(),
             fileSizeHuman = Formatter.formatShortFileSize(app.applicationContext, fileSize),
-            zipFile = filesReady.zip,
+            zipFile = filesZipping.zip,
         ).apply {
-            addFiles(filesReady.files)
+            addFiles(filesZipping.files)
         }
     }
 

--- a/app/src/main/java/org/onionshare/android/server/WebserverManager.kt
+++ b/app/src/main/java/org/onionshare/android/server/WebserverManager.kt
@@ -1,5 +1,6 @@
 package org.onionshare.android.server
 
+import android.net.TrafficStats
 import android.util.Base64
 import android.util.Base64.NO_PADDING
 import android.util.Base64.URL_SAFE
@@ -53,6 +54,7 @@ class WebserverManager @Inject constructor() {
     fun start(sendPage: SendPage): StateFlow<State> {
         val staticPath = getStaticPath()
         val staticPathMap = mapOf("static_url_path" to staticPath)
+        TrafficStats.setThreadStatsTag(0x42)
         server = embeddedServer(Netty, PORT, watchPaths = emptyList()) {
             install(CallLogging)
             install(Pebble) {

--- a/app/src/main/java/org/onionshare/android/tor/TorManager.kt
+++ b/app/src/main/java/org/onionshare/android/tor/TorManager.kt
@@ -94,8 +94,10 @@ class TorManager @Inject constructor(
         }
         val onion = (state.value as? TorState.Starting)?.onion
         // descriptor upload counts as 90%
-        if (onion != null && keyword == EVENT_HS_DESC && data.startsWith("UPLOAD $onion")) {
-            _state.value = TorState.Starting(90, onion)
+        if (state.value !is TorState.Started) {
+            if (onion != null && keyword == EVENT_HS_DESC && data.startsWith("UPLOAD $onion")) {
+                _state.value = TorState.Starting(90, onion)
+            }
         }
         // We consider already the first upload of the onion descriptor as started (100%).
         // In practice, more uploads are needed for the onion service to be reachable.

--- a/app/src/main/java/org/onionshare/android/tor/TorManager.kt
+++ b/app/src/main/java/org/onionshare/android/tor/TorManager.kt
@@ -125,7 +125,7 @@ class TorManager @Inject constructor(
         }
         startLatch?.await() ?: error("startLatch was null")
         startLatch = null
-        onTorStarted()
+        onTorServiceStarted()
     }
 
     fun stop() {
@@ -144,7 +144,7 @@ class TorManager @Inject constructor(
     }
 
     @Suppress("BlockingMethodInNonBlockingContext")
-    private suspend fun onTorStarted() = withContext(Dispatchers.IO) {
+    private suspend fun onTorServiceStarted() = withContext(Dispatchers.IO) {
         _state.value = TorState.Starting(5)
         controlConnection = startControlConnection().apply {
             addRawEventListener(onionListener)

--- a/app/src/main/java/org/onionshare/android/tor/TorManager.kt
+++ b/app/src/main/java/org/onionshare/android/tor/TorManager.kt
@@ -9,16 +9,19 @@ import android.net.LocalSocket
 import android.net.LocalSocketAddress
 import android.net.LocalSocketAddress.Namespace.FILESYSTEM
 import androidx.core.content.ContextCompat.startForegroundService
-import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.withContext
 import net.freehaven.tor.control.RawEventListener
 import net.freehaven.tor.control.TorControlCommands.EVENT_CIRCUIT_STATUS
 import net.freehaven.tor.control.TorControlCommands.EVENT_ERR_MSG
 import net.freehaven.tor.control.TorControlCommands.EVENT_HS_DESC
-import net.freehaven.tor.control.TorControlCommands.EVENT_NEW_DESC
-import net.freehaven.tor.control.TorControlCommands.EVENT_OR_CONN_STATUS
+import net.freehaven.tor.control.TorControlCommands.EVENT_STATUS_CLIENT
 import net.freehaven.tor.control.TorControlCommands.EVENT_WARN_MSG
 import net.freehaven.tor.control.TorControlCommands.HS_ADDRESS
 import net.freehaven.tor.control.TorControlConnection
+import org.onionshare.android.server.PORT
 import org.slf4j.LoggerFactory.getLogger
 import org.torproject.jni.TorService
 import org.torproject.jni.TorService.ACTION_STATUS
@@ -28,99 +31,129 @@ import java.io.FileInputStream
 import java.io.FileOutputStream
 import java.io.IOException
 import java.util.Collections
+import java.util.concurrent.CountDownLatch
 import javax.inject.Inject
 import javax.inject.Singleton
-import kotlin.coroutines.resume
-import kotlin.coroutines.resumeWithException
+import kotlin.math.roundToInt
 
 private val LOG = getLogger(TorManager::class.java)
 private val EVENTS = listOf(
     EVENT_CIRCUIT_STATUS, // this one is needed for TorService to function
-    EVENT_OR_CONN_STATUS, // can be removed before release
     EVENT_HS_DESC,
-    EVENT_NEW_DESC, // can be removed before release
+    EVENT_STATUS_CLIENT,
     EVENT_WARN_MSG,
     EVENT_ERR_MSG,
 )
+private val BOOTSTRAP_REGEX = Regex("^NOTICE BOOTSTRAP PROGRESS=([0-9]{1,3}) .*$")
 
 @Singleton
 class TorManager @Inject constructor(
     private val app: Application,
 ) {
-    private var broadcastReceiver: BroadcastReceiver? = null
+    private val _state = MutableStateFlow<TorState>(TorState.Stopped)
+    internal val state: StateFlow<TorState> = _state
+    private var broadcastReceiver = object : BroadcastReceiver() {
+        /**
+         * Attention: This gets executes on UI Thread
+         */
+        override fun onReceive(context: Context, i: Intent) {
+            when (i.getStringExtra(EXTRA_STATUS)) {
+                TorService.STATUS_STARTING -> LOG.debug("TorService: Starting...")
+                TorService.STATUS_ON -> {
+                    LOG.debug("TorService: Started")
+                    startLatch?.countDown() ?: error("startLatch was null when Tor started.")
+                }
+                // FIXME When we stop unplanned, we need to inform the ShareManager
+                //  that we stopped, so it can clear its state up, stopping webserver, etc.
+                TorService.STATUS_STOPPING -> LOG.debug("TorService: Stopping...")
+                TorService.STATUS_OFF -> LOG.debug("TorService: Stopped")
+            }
+        }
+    }
+
+    @Volatile
+    private var broadcastReceiverRegistered = false
+    private var startLatch: CountDownLatch? = null
+
+    @Volatile
+    private var controlConnection: TorControlConnection? = null
+    private val onionListener = RawEventListener { keyword, data ->
+        // TODO consider removing the logging below before release
+        LOG.debug("$keyword: $data")
+        // bootstrapping gets 70% of our progress
+        if (keyword == EVENT_STATUS_CLIENT) {
+            val matchResult = BOOTSTRAP_REGEX.matchEntire(data)
+            val percent = matchResult?.groupValues?.get(1)?.toIntOrNull()
+            if (percent != null) {
+                val progress = (percent * 0.7).roundToInt()
+                val newState = (state.value as? TorState.Starting)?.copy(progress = progress)
+                    ?: TorState.Starting(progress)
+                _state.value = newState
+            }
+            return@RawEventListener
+        }
+        val onion = (state.value as? TorState.Starting)?.onion
+        // descriptor upload counts as 90%
+        if (onion != null && keyword == EVENT_HS_DESC && data.startsWith("UPLOAD $onion")) {
+            _state.value = TorState.Starting(90, onion)
+        }
+        // We consider already the first upload of the onion descriptor as started (100%).
+        // In practice, more uploads are needed for the onion service to be reachable.
+        if (onion != null && keyword == EVENT_HS_DESC && data.startsWith("UPLOADED $onion")) {
+            _state.value = TorState.Started(onion)
+        }
+    }
 
     /**
      * Starts [TorService] and creates a new onion service.
      * Suspends until the address of the onion service is available.
      */
-    suspend fun start(port: Int): String {
-        startAndGetPath()
-        return onTorStarted(port)
-    }
+    @Suppress("BlockingMethodInNonBlockingContext")
+    suspend fun start() = withContext(Dispatchers.IO) {
+        if (state.value !is TorState.Stopped) stop()
 
-    fun stop() {
-        LOG.info("Stopping...")
-        Intent(app, ShareService::class.java).also { intent ->
-            app.stopService(intent)
-        }
-        broadcastReceiver?.let { app.unregisterReceiver(it) }
-        broadcastReceiver = null
-        LOG.info("Stopped")
-    }
-
-    private suspend fun startAndGetPath(): Unit = suspendCancellableCoroutine { continuation ->
         LOG.info("Starting...")
-        broadcastReceiver = object : BroadcastReceiver() {
-            /**
-             * Attention: This gets executes on UI Thread
-             */
-            override fun onReceive(context: Context, i: Intent) {
-                when (i.getStringExtra(EXTRA_STATUS)) {
-                    TorService.STATUS_STARTING -> LOG.debug("TorService: Starting...")
-                    TorService.STATUS_ON -> {
-                        LOG.debug("TorService: Started")
-                        if (continuation.isActive) continuation.resume(Unit)
-                    }
-                    // FIXME When we stop unplanned, we need to inform the ShareManager
-                    //  that we stopped, so it can clear its state up, stopping webserver, etc.
-                    TorService.STATUS_STOPPING -> LOG.debug("TorService: Stopping...")
-                    TorService.STATUS_OFF -> LOG.debug("TorService: Stopped")
-                }
-            }
-        }
+        _state.value = TorState.Starting(0)
+        startLatch = CountDownLatch(1)
         app.registerReceiver(broadcastReceiver, IntentFilter(ACTION_STATUS))
+        broadcastReceiverRegistered = true
 
         Intent(app, ShareService::class.java).also { intent ->
             startForegroundService(app, intent)
         }
-        // this method suspends here until it the continuation in the broadcastReceiver resumes it
+        startLatch?.await() ?: error("startLatch was null")
+        startLatch = null
+        onTorStarted()
     }
 
-    private suspend fun onTorStarted(port: Int): String = suspendCancellableCoroutine { cont ->
-        try {
-            var onion: String? = null
-            val controlConnection = startControlConnection().apply {
-                val onionListener = RawEventListener { keyword, data ->
-                    if (onion != null && keyword == EVENT_HS_DESC && data.startsWith("UPLOADED $onion")) {
-                        if (cont.isActive) cont.resume("$onion.onion")
-                    }
-                    // TODO consider removing the logging below before release
-                    LOG.debug("$keyword: $data")
-                }
-                addRawEventListener(onionListener)
-                // create listeners as the first thing to prevent modification while already receiving events
-                launchThread(true)
-                authenticate(ByteArray(0))
-                takeOwnership()
-                setEvents(EVENTS)
-            }
-            onion = createOnionService(controlConnection, port)
-        } catch (e: Exception) {
-            // gets caught and logged by caller
-            if (cont.isActive) cont.resumeWithException(e)
-            else LOG.error("Error when starting Tor", e)
+    fun stop() {
+        LOG.info("Stopping...")
+        _state.value = TorState.Stopping
+        controlConnection = null
+        Intent(app, ShareService::class.java).also { intent ->
+            app.stopService(intent)
         }
-        // this method suspends here until it the continuation in onionListener resumes it
+        if (broadcastReceiverRegistered) {
+            app.unregisterReceiver(broadcastReceiver)
+            broadcastReceiverRegistered = false
+        }
+        LOG.info("Stopped")
+        _state.value = TorState.Stopped
+    }
+
+    @Suppress("BlockingMethodInNonBlockingContext")
+    private suspend fun onTorStarted() = withContext(Dispatchers.IO) {
+        _state.value = TorState.Starting(5)
+        controlConnection = startControlConnection().apply {
+            addRawEventListener(onionListener)
+            // create listeners as the first thing to prevent modification while already receiving events
+            launchThread(true)
+            authenticate(ByteArray(0))
+            takeOwnership()
+            setEvents(EVENTS)
+            val onion = createOnionService()
+            _state.value = TorState.Starting(10, onion)
+        }
     }
 
     /**
@@ -128,18 +161,18 @@ class TorManager @Inject constructor(
      * and returns its address (without the final .onion part).
      */
     @Throws(IOException::class)
-    private fun createOnionService(
-        controlConnection: TorControlConnection,
-        port: Int,
-    ): String {
+    @Suppress("BlockingMethodInNonBlockingContext")
+    private suspend fun TorControlConnection.createOnionService(): String = withContext(Dispatchers.IO) {
         LOG.error("Starting hidden service...")
-        val portLines = Collections.singletonMap(80, "127.0.0.1:$port")
-        val response = controlConnection.addOnion("NEW:ED25519-V3", portLines, null)
-        return response[HS_ADDRESS]
+        val portLines = Collections.singletonMap(80, "127.0.0.1:$PORT")
+        val response = addOnion("NEW:ED25519-V3", portLines, null)
+        response[HS_ADDRESS]
             ?: throw IOException("Tor did not return a hidden service address")
     }
 
-    private fun startControlConnection(): TorControlConnection {
+    @Throws(IOException::class)
+    @Suppress("BlockingMethodInNonBlockingContext")
+    private suspend fun startControlConnection(): TorControlConnection = withContext(Dispatchers.IO) {
         val localSocketAddress = LocalSocketAddress(getControlPath(), FILESYSTEM)
         val client = LocalSocket()
         client.connect(localSocketAddress)
@@ -149,7 +182,7 @@ class TorManager @Inject constructor(
         val controlFileDescriptor = client.fileDescriptor
         val inputStream = FileInputStream(controlFileDescriptor)
         val outputStream = FileOutputStream(controlFileDescriptor)
-        return TorControlConnection(inputStream, outputStream)
+        TorControlConnection(inputStream, outputStream)
     }
 
     /**
@@ -158,10 +191,10 @@ class TorManager @Inject constructor(
      * Note: Exposing this through TorService was rejected by upstream.
      *       https://github.com/guardianproject/tor-android/pull/61
      */
-    private fun getControlPath(): String {
+    private suspend fun getControlPath(): String = withContext(Dispatchers.IO) {
         val serviceDir = app.applicationContext.getDir(TorService::class.java.simpleName, 0)
         val dataDir = File(serviceDir, "data")
-        return File(dataDir, "ControlSocket").absolutePath
+        File(dataDir, "ControlSocket").absolutePath
     }
 
 }

--- a/app/src/main/java/org/onionshare/android/tor/TorState.kt
+++ b/app/src/main/java/org/onionshare/android/tor/TorState.kt
@@ -1,0 +1,18 @@
+package org.onionshare.android.tor
+
+sealed class TorState {
+
+    object Stopped : TorState()
+
+    data class Starting(
+        val progress: Int,
+        val onion: String? = null,
+    ) : TorState()
+
+    data class Started(
+        val onion: String,
+    ) : TorState()
+
+    object Stopping : TorState()
+
+}

--- a/app/src/main/java/org/onionshare/android/ui/MainActivity.kt
+++ b/app/src/main/java/org/onionshare/android/ui/MainActivity.kt
@@ -47,8 +47,7 @@ class MainActivity : ComponentActivity() {
     }
 
     private val contentLauncher = registerForActivityResult(OpenDocuments()) { uris ->
-        // TODO we might need to set this to true, or removing code that takes permissions
-        viewModel.onUrisReceived(uris, false)
+        viewModel.onUrisReceived(uris, true)
     }
 
     /**
@@ -96,8 +95,9 @@ class MainActivity : ComponentActivity() {
 
 private class OpenDocuments : OpenMultipleDocuments() {
     override fun createIntent(context: Context, input: Array<String>): Intent {
-        val intent = super.createIntent(context, input)
-        intent.addFlags(FLAG_GRANT_READ_URI_PERMISSION or FLAG_GRANT_PERSISTABLE_URI_PERMISSION)
-        return intent
+        return super.createIntent(context, input).apply {
+            addFlags(FLAG_GRANT_READ_URI_PERMISSION)
+            addFlags(FLAG_GRANT_PERSISTABLE_URI_PERMISSION)
+        }
     }
 }

--- a/app/src/main/java/org/onionshare/android/ui/MainActivity.kt
+++ b/app/src/main/java/org/onionshare/android/ui/MainActivity.kt
@@ -2,7 +2,10 @@ package org.onionshare.android.ui
 
 import android.annotation.SuppressLint
 import android.content.ActivityNotFoundException
+import android.content.Context
 import android.content.Intent
+import android.content.Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION
+import android.content.Intent.FLAG_GRANT_READ_URI_PERMISSION
 import android.net.Uri
 import android.os.Bundle
 import android.provider.Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS
@@ -11,6 +14,7 @@ import android.widget.Toast.LENGTH_SHORT
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.result.contract.ActivityResultContracts.GetMultipleContents
+import androidx.activity.result.contract.ActivityResultContracts.OpenMultipleDocuments
 import androidx.activity.result.contract.ActivityResultContracts.StartActivityForResult
 import androidx.activity.viewModels
 import androidx.compose.material.MaterialTheme
@@ -42,8 +46,17 @@ class MainActivity : ComponentActivity() {
         }
     }
 
-    private val contentLauncher = registerForActivityResult(GetMultipleContents()) { uris ->
-        viewModel.onUrisReceived(uris)
+    private val contentLauncher = registerForActivityResult(OpenDocuments()) { uris ->
+        // TODO we might need to set this to true, or removing code that takes permissions
+        viewModel.onUrisReceived(uris, false)
+    }
+
+    /**
+     * Some phones seem to have a messed up Storage Access Framework and do not support OPEN_DOCUMENT.
+     * This uses GET_CONTENT as a fall-back.
+     */
+    private val contentFallbackLauncher = registerForActivityResult(GetMultipleContents()) { uris ->
+        viewModel.onUrisReceived(uris, false)
     }
 
     private val batteryLauncher = registerForActivityResult(StartActivityForResult()) {
@@ -55,9 +68,13 @@ class MainActivity : ComponentActivity() {
 
     private fun onFabClicked() {
         try {
-            contentLauncher.launch("*/*")
+            contentLauncher.launch(arrayOf("*/*"))
         } catch (e: ActivityNotFoundException) {
-            Toast.makeText(this, R.string.add_files_not_supported, LENGTH_SHORT).show()
+            try {
+                contentFallbackLauncher.launch("*/*")
+            } catch (e: ActivityNotFoundException) {
+                Toast.makeText(this, R.string.add_files_not_supported, LENGTH_SHORT).show()
+            }
         }
     }
 
@@ -74,5 +91,13 @@ class MainActivity : ComponentActivity() {
         } else {
             viewModel.onSheetButtonClicked()
         }
+    }
+}
+
+private class OpenDocuments : OpenMultipleDocuments() {
+    override fun createIntent(context: Context, input: Array<String>): Intent {
+        val intent = super.createIntent(context, input)
+        intent.addFlags(FLAG_GRANT_READ_URI_PERMISSION or FLAG_GRANT_PERSISTABLE_URI_PERMISSION)
+        return intent
     }
 }

--- a/app/src/main/java/org/onionshare/android/ui/MainViewModel.kt
+++ b/app/src/main/java/org/onionshare/android/ui/MainViewModel.kt
@@ -22,11 +22,11 @@ class MainViewModel @Inject constructor(
 
     val shareState: StateFlow<ShareUiState> = shareManager.shareState
 
-    fun onUrisReceived(uris: List<Uri>) {
+    fun onUrisReceived(uris: List<Uri>, takePermission: Boolean) {
         if (uris.isEmpty()) return // user backed out of select activity
 
         viewModelScope.launch {
-            shareManager.addFiles(uris)
+            shareManager.addFiles(uris, takePermission)
         }
     }
 

--- a/app/src/main/java/org/onionshare/android/ui/ShareBottomSheet.kt
+++ b/app/src/main/java/org/onionshare/android/ui/ShareBottomSheet.kt
@@ -7,11 +7,13 @@ import android.content.res.Configuration.UI_MODE_NIGHT_YES
 import android.widget.Toast
 import android.widget.Toast.LENGTH_SHORT
 import androidx.annotation.StringRes
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.requiredSize
 import androidx.compose.foundation.layout.size
@@ -21,7 +23,9 @@ import androidx.compose.material.Button
 import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.Divider
 import androidx.compose.material.Icon
+import androidx.compose.material.LinearProgressIndicator
 import androidx.compose.material.MaterialTheme
+import androidx.compose.material.ProgressIndicatorDefaults
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
@@ -30,6 +34,7 @@ import androidx.compose.material.icons.filled.Circle
 import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.filled.DragHandle
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment.Companion.CenterHorizontally
 import androidx.compose.ui.Alignment.Companion.CenterVertically
 import androidx.compose.ui.Modifier
@@ -117,7 +122,7 @@ fun BottomSheet(state: ShareUiState, onSheetButtonClicked: () -> Unit) {
                 modifier = Modifier.padding(start = 16.dp),
             )
         }
-        Divider(thickness = 2.dp)
+        ProgressDivider(state)
         val colorControlNormal = MaterialTheme.colors.onSurface.copy(alpha = 0.12f)
         if (state is ShareUiState.Sharing) {
             Text(
@@ -184,6 +189,23 @@ fun BottomSheet(state: ShareUiState, onSheetButtonClicked: () -> Unit) {
     }
 }
 
+@Composable
+fun ProgressDivider(state: ShareUiState) {
+    if (state is ShareUiState.Starting) {
+        val animatedProgress by animateFloatAsState(
+            targetValue = state.totalProgress,
+            animationSpec = ProgressIndicatorDefaults.ProgressAnimationSpec
+        )
+        LinearProgressIndicator(
+            progress = animatedProgress,
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(2.dp))
+    } else {
+        Divider(thickness = 2.dp)
+    }
+}
+
 @Preview(showBackground = true, uiMode = UI_MODE_NIGHT_YES)
 @Composable
 fun ShareBottomSheetReadyPreview() {
@@ -203,7 +225,7 @@ fun ShareBottomSheetStartingPreview() {
     OnionshareTheme {
         Surface(color = MaterialTheme.colors.background) {
             BottomSheet(
-                state = ShareUiState.Starting(emptyList(), 0L),
+                state = ShareUiState.Starting(emptyList(), 0L, 25, 50),
                 onSheetButtonClicked = {},
             )
         }

--- a/app/src/main/java/org/onionshare/android/ui/ShareUiState.kt
+++ b/app/src/main/java/org/onionshare/android/ui/ShareUiState.kt
@@ -16,8 +16,20 @@ sealed class ShareUiState(open val files: List<SendFile>, open val totalSize: Lo
     data class Starting(
         override val files: List<SendFile>,
         override val totalSize: Long,
+        val zipPercent: Int,
+        val torPercent: Int,
     ) : ShareUiState(files, totalSize) {
         override val allowsModifyingFiles = false
+        val totalProgress: Float
+            get() {
+                val sum = zipPercent.toFloat() / 2 + torPercent.toFloat() / 2
+                return sum / 100
+            }
+
+        init {
+            require(zipPercent in 0..100)
+            require(torPercent in 0..100)
+        }
     }
 
     data class Sharing(


### PR DESCRIPTION
Note that `TorManager` will probably still need to undergo substantial changes to report ongoing progress rather than suspending its `start()` method until we have fully started. However, this fixes the existing issues with it.

This now also adds a commit to address #15, but has only the first half activated.

Fixes #18, #19, #20, #25