### PR TITLE
Handle FileNotFoundException

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@
 .cxx
 local.properties
 /Gemfile.lock
+/.bundle/config

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,6 @@
 source "https://rubygems.org"
 
 gem "fastlane"
+
+plugins_path = File.join(File.dirname(__FILE__), 'fastlane', 'Pluginfile')
+eval_gemfile(plugins_path) if File.exist?(plugins_path)

--- a/app/src/main/java/org/onionshare/android/files/FileManager.kt
+++ b/app/src/main/java/org/onionshare/android/files/FileManager.kt
@@ -79,6 +79,9 @@ class FileManager @Inject constructor(
                         } catch (e: FileNotFoundException) {
                             LOG.warn("Error while opening file: ", e)
                             throw FileErrorException(file)
+                        } catch (e: SecurityException) {
+                            LOG.warn("Error while opening file: SecurityException")
+                            throw FileErrorException(file)
                         }
                     }
                 }

--- a/app/src/main/java/org/onionshare/android/ui/FileList.kt
+++ b/app/src/main/java/org/onionshare/android/ui/FileList.kt
@@ -183,7 +183,7 @@ fun FileListPreviewDark() {
                 SendFile("foo bar file", "1337 KiB", 1, Uri.parse("/foo"), null),
             )
             val mutableState = remember {
-                mutableStateOf(ShareUiState.FilesAdded(files, files.sumOf { it.size }))
+                mutableStateOf(ShareUiState.FilesAdded(files))
             }
             FileList(Modifier, mutableState, {}) {}
         }
@@ -199,9 +199,8 @@ fun FileListPreview() {
             SendFile("bar", "42 MiB", 2, Uri.parse("/bar"), "video/mp4"),
             SendFile("foo bar", "23 MiB", 3, Uri.parse("/foo/bar"), null),
         )
-        val totalSize = files.sumOf { it.size }
         val mutableState = remember {
-            mutableStateOf(ShareUiState.FilesAdded(files, totalSize))
+            mutableStateOf(ShareUiState.FilesAdded(files))
         }
         FileList(Modifier, mutableState, {}) {}
     }

--- a/app/src/main/java/org/onionshare/android/ui/MainUi.kt
+++ b/app/src/main/java/org/onionshare/android/ui/MainUi.kt
@@ -225,7 +225,7 @@ fun DefaultPreview() {
     )
     OnionshareTheme {
         MainUi(
-            stateFlow = MutableStateFlow(ShareUiState.FilesAdded(files, 1337L)),
+            stateFlow = MutableStateFlow(ShareUiState.FilesAdded(files)),
             onFabClicked = {},
             onFileRemove = {},
             onRemoveAll = {},

--- a/app/src/main/java/org/onionshare/android/ui/MainUi.kt
+++ b/app/src/main/java/org/onionshare/android/ui/MainUi.kt
@@ -88,9 +88,15 @@ fun MainUi(
             delay(750)
             scaffoldState.bottomSheetState.expand()
         }
-        if (state.value is ShareUiState.Error) {
-            val text = stringResource(R.string.share_error_snackbar_text)
-            val action = stringResource(R.string.share_error_snackbar_action)
+        val uiState = state.value
+        if (uiState is ShareUiState.Error) {
+            val errorFile = uiState.errorFile
+            val text = if (errorFile != null) {
+                stringResource(R.string.share_error_file_snackbar_text, errorFile.basename)
+            } else {
+                stringResource(R.string.share_error_snackbar_text)
+            }
+            val action = if (uiState.files.isEmpty()) null else stringResource(R.string.share_error_snackbar_action)
             LaunchedEffect("showSnackbar") {
                 val snackbarResult = scaffoldState.snackbarHostState.showSnackbar(
                     message = text,
@@ -100,22 +106,22 @@ fun MainUi(
                 if (snackbarResult == SnackbarResult.ActionPerformed) onSheetButtonClicked()
             }
         }
-        if (!state.value.collapsableSheet && scaffoldState.bottomSheetState.isCollapsed) {
+        if (!uiState.collapsableSheet && scaffoldState.bottomSheetState.isCollapsed) {
             // ensure the bottom sheet is visible
-            LaunchedEffect(state.value) {
+            LaunchedEffect(uiState) {
                 scaffoldState.bottomSheetState.expand()
             }
         }
         BottomSheetScaffold(
             topBar = { ActionBar(R.string.app_name) },
             floatingActionButton = {
-                Fab(state.value, scaffoldState.bottomSheetState, onFabClicked)
+                Fab(uiState, scaffoldState.bottomSheetState, onFabClicked)
             },
-            sheetGesturesEnabled = state.value.collapsableSheet,
+            sheetGesturesEnabled = uiState.collapsableSheet,
             sheetPeekHeight = bottomSheetPeekHeight,
             sheetShape = RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp),
             scaffoldState = scaffoldState,
-            sheetContent = { BottomSheet(state.value, onSheetButtonClicked) }
+            sheetContent = { BottomSheet(uiState, onSheetButtonClicked) }
         ) {
             MainContent(stateFlow, offset, onFileRemove, onRemoveAll)
         }

--- a/app/src/main/java/org/onionshare/android/ui/ShareBottomSheet.kt
+++ b/app/src/main/java/org/onionshare/android/ui/ShareBottomSheet.kt
@@ -217,7 +217,7 @@ fun ShareBottomSheetReadyPreview() {
     OnionshareTheme {
         Surface(color = MaterialTheme.colors.background) {
             BottomSheet(
-                state = ShareUiState.FilesAdded(emptyList(), 0L),
+                state = ShareUiState.FilesAdded(emptyList()),
                 onSheetButtonClicked = {},
             )
         }
@@ -230,7 +230,7 @@ fun ShareBottomSheetStartingPreview() {
     OnionshareTheme {
         Surface(color = MaterialTheme.colors.background) {
             BottomSheet(
-                state = ShareUiState.Starting(emptyList(), 0L, 25, 50),
+                state = ShareUiState.Starting(emptyList(), 25, 50),
                 onSheetButtonClicked = {},
             )
         }
@@ -245,7 +245,6 @@ fun ShareBottomSheetSharingPreview() {
             BottomSheet(
                 state = ShareUiState.Sharing(
                     emptyList(),
-                    0L,
                     "http://openpravyvc6spbd4flzn4g2iqu4sxzsizbtb5aqec25t76dnoo5w7yd.onion/",
                 ),
                 onSheetButtonClicked = {},
@@ -266,7 +265,7 @@ fun ShareBottomSheetCompletePreview() {
     OnionshareTheme {
         Surface(color = MaterialTheme.colors.background) {
             BottomSheet(
-                state = ShareUiState.Complete(emptyList(), 0L),
+                state = ShareUiState.Complete(emptyList()),
                 onSheetButtonClicked = {},
             )
         }

--- a/app/src/main/java/org/onionshare/android/ui/ShareUiState.kt
+++ b/app/src/main/java/org/onionshare/android/ui/ShareUiState.kt
@@ -3,26 +3,23 @@ package org.onionshare.android.ui
 import org.onionshare.android.files.totalSize
 import org.onionshare.android.server.SendFile
 
-sealed class ShareUiState(open val files: List<SendFile>, open val totalSize: Long) {
+sealed class ShareUiState(val files: List<SendFile>) {
 
     open val allowsModifyingFiles = true
     open val collapsableSheet = false
+    val totalSize: Long = files.totalSize
 
-    object NoFiles : ShareUiState(emptyList(), 0L)
+    object NoFiles : ShareUiState(emptyList())
 
-    data class FilesAdded(
-        override val files: List<SendFile>,
-        override val totalSize: Long,
-    ) : ShareUiState(files, totalSize) {
-        constructor(files: List<SendFile>) : this(files, files.totalSize)
-    }
+    class FilesAdded(
+        files: List<SendFile>,
+    ) : ShareUiState(files)
 
-    data class Starting(
-        override val files: List<SendFile>,
-        override val totalSize: Long,
+    class Starting(
+        files: List<SendFile>,
         val zipPercent: Int,
         val torPercent: Int,
-    ) : ShareUiState(files, totalSize) {
+    ) : ShareUiState(files) {
         override val allowsModifyingFiles = false
         val totalProgress: Float
             get() {
@@ -36,24 +33,21 @@ sealed class ShareUiState(open val files: List<SendFile>, open val totalSize: Lo
         }
     }
 
-    data class Sharing(
-        override val files: List<SendFile>,
-        override val totalSize: Long,
+    class Sharing(
+        files: List<SendFile>,
         val onionAddress: String,
-    ) : ShareUiState(files, totalSize) {
+    ) : ShareUiState(files) {
         override val allowsModifyingFiles = false
         override val collapsableSheet = true
     }
 
-    data class Complete(
-        override val files: List<SendFile>,
-        override val totalSize: Long,
-    ) : ShareUiState(files, totalSize)
+    class Complete(
+        files: List<SendFile>,
+    ) : ShareUiState(files)
 
-    data class Error(
-        override val files: List<SendFile>,
-        override val totalSize: Long,
+    class Error(
+        files: List<SendFile>,
         val errorFile: SendFile? = null,
-    ) : ShareUiState(files, totalSize)
+    ) : ShareUiState(files)
 
 }

--- a/app/src/main/java/org/onionshare/android/ui/ShareUiState.kt
+++ b/app/src/main/java/org/onionshare/android/ui/ShareUiState.kt
@@ -1,5 +1,6 @@
 package org.onionshare.android.ui
 
+import org.onionshare.android.files.totalSize
 import org.onionshare.android.server.SendFile
 
 sealed class ShareUiState(open val files: List<SendFile>, open val totalSize: Long) {
@@ -12,7 +13,9 @@ sealed class ShareUiState(open val files: List<SendFile>, open val totalSize: Lo
     data class FilesAdded(
         override val files: List<SendFile>,
         override val totalSize: Long,
-    ) : ShareUiState(files, totalSize)
+    ) : ShareUiState(files, totalSize) {
+        constructor(files: List<SendFile>) : this(files, files.totalSize)
+    }
 
     data class Starting(
         override val files: List<SendFile>,
@@ -50,6 +53,7 @@ sealed class ShareUiState(open val files: List<SendFile>, open val totalSize: Lo
     data class Error(
         override val files: List<SendFile>,
         override val totalSize: Long,
+        val errorFile: SendFile? = null,
     ) : ShareUiState(files, totalSize)
 
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -28,5 +28,6 @@
     <string name="sharing_channel_name">File sharing notification</string>
     <string name="sharing_notification_title">Currently sharing files</string>
     <string name="share_error_snackbar_text">Could not start OnionShare</string>
+    <string name="share_error_file_snackbar_text">Could not open %s. Removed.</string>
     <string name="share_error_snackbar_action">Retry</string>
 </resources>

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -50,7 +50,7 @@ platform :android do
 
 	# Github: Ensure that tag exists and push it
 	git_tag_exists(tag: version_name)
-	push_git_tags(tag: version_name)
+	push_git_tags(remote: "upstream", tag: version_name)
 
     upload_to_play_store(
         track: 'beta',


### PR DESCRIPTION
A video file from an erroneous screencast attempt can't be opened and throws a `FileNotFoundException` when selected. This PR tells user about this kind of problem and removes the file from the list, so the user can try again without it.

Closes #15 