### PR TITLE
Added shadow overlay to bottom sheet

### DIFF
--- a/app/src/main/java/org/onionshare/android/ui/CustomizedShadow.kt
+++ b/app/src/main/java/org/onionshare/android/ui/CustomizedShadow.kt
@@ -1,0 +1,76 @@
+package org.onionshare.android.ui
+
+import android.graphics.BlurMaskFilter
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.DrawModifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.*
+import androidx.compose.ui.graphics.drawscope.ContentDrawScope
+import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
+
+fun Modifier.shadow(
+    shadow: Shadow,
+    shape: Shape = RectangleShape
+) = this.then(
+    ShadowModifier(shadow, shape)
+)
+
+private class ShadowModifier(
+    val shadow: Shadow,
+    val shape: Shape
+) : DrawModifier {
+
+    override fun ContentDrawScope.draw() {
+        drawIntoCanvas { canvas ->
+            val paint = Paint().apply {
+                color = shadow.color
+                asFrameworkPaint().apply {
+                    maskFilter = BlurMaskFilter(
+                        convertRadiusToSigma(shadow.blurRadius),
+                        BlurMaskFilter.Blur.NORMAL
+                    )
+                }
+            }
+            shape.createOutline(
+                size, layoutDirection, this
+            ).let { outline ->
+                canvas.drawWithOffset(shadow.offset) {
+                    when (outline) {
+                        is Outline.Rectangle -> {
+                            drawRect(outline.rect, paint)
+                        }
+                        is Outline.Rounded -> {
+                            drawPath(
+                                Path().apply { addRoundRect(outline.roundRect) },
+                                paint
+                            )
+                        }
+                        is Outline.Generic -> {
+                            drawPath(outline.path, paint)
+                        }
+                    }
+                }
+            }
+        }
+        drawContent()
+    }
+
+    private fun convertRadiusToSigma(
+        radius: Float,
+        enable: Boolean = true
+    ): Float = if (enable) {
+        (radius * 0.57735 + 0.5).toFloat()
+    } else {
+        radius
+    }
+
+    private fun Canvas.drawWithOffset(
+        offset: Offset,
+        block: Canvas.() -> Unit
+    ) {
+        save()
+        translate(offset.x, offset.y)
+        block()
+        restore()
+    }
+}

--- a/app/src/main/java/org/onionshare/android/ui/share/ShareBottomSheet.kt
+++ b/app/src/main/java/org/onionshare/android/ui/share/ShareBottomSheet.kt
@@ -10,24 +10,10 @@ import androidx.annotation.StringRes
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.requiredSize
-import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.selection.SelectionContainer
-import androidx.compose.material.Button
-import androidx.compose.material.ButtonDefaults
-import androidx.compose.material.Divider
-import androidx.compose.material.Icon
-import androidx.compose.material.LinearProgressIndicator
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.ProgressIndicatorDefaults
-import androidx.compose.material.Surface
-import androidx.compose.material.Text
+import androidx.compose.material.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.Circle
@@ -38,8 +24,10 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment.Companion.CenterHorizontally
 import androidx.compose.ui.Alignment.Companion.CenterVertically
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.Shadow
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
@@ -51,12 +39,8 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import org.onionshare.android.R
 import org.onionshare.android.ui.StyledLegacyText
-import org.onionshare.android.ui.theme.IndicatorReady
-import org.onionshare.android.ui.theme.IndicatorSharing
-import org.onionshare.android.ui.theme.IndicatorStarting
-import org.onionshare.android.ui.theme.OnionBlue
-import org.onionshare.android.ui.theme.OnionRed
-import org.onionshare.android.ui.theme.OnionshareTheme
+import org.onionshare.android.ui.shadow
+import org.onionshare.android.ui.theme.*
 
 private data class BottomSheetUi(
     val indicatorIcon: ImageVector = Icons.Filled.Circle,
@@ -99,98 +83,114 @@ private fun getBottomSheetUi(state: ShareUiState) = when (state) {
 fun BottomSheet(state: ShareUiState, onSheetButtonClicked: () -> Unit) {
     if (state is ShareUiState.NoFiles) return
     val sheetUi = getBottomSheetUi(state)
-    Column {
-        if (state.collapsableSheet) Image(
-            imageVector = Icons.Filled.DragHandle,
-            contentDescription = null,
-            colorFilter = ColorFilter.tint(Color.Gray),
-            contentScale = ContentScale.Crop,
-            modifier = Modifier
-                .size(24.dp, 14.dp)
-                .padding(top = 4.dp)
-                .align(CenterHorizontally),
-        )
-        val topPadding = if (state.collapsableSheet) 0.dp else 16.dp
-        Row(
-            verticalAlignment = CenterVertically,
-            modifier = Modifier.padding(start = 16.dp, top = topPadding, bottom = 16.dp),
+    Surface(
+        color = Color.White,
+        elevation = 8.dp,
+        modifier = Modifier
+            .padding(top = 8.dp)
+            .shadow(
+                shadow = Shadow(
+                    color = DarkShadow,
+                    offset = Offset(0f, -20f),
+                    blurRadius = 15f
+                )
+            )
         ) {
-            Icon(
-                imageVector = sheetUi.indicatorIcon,
-                tint = sheetUi.indicatorColor,
+        Column(
+            modifier = Modifier.padding(top = 8.dp)
+        ) {
+            if (state.collapsableSheet) Image(
+                imageVector = Icons.Filled.DragHandle,
                 contentDescription = null,
-                modifier = Modifier.size(16.dp),
+                colorFilter = ColorFilter.tint(Color.Gray),
+                contentScale = ContentScale.Crop,
+                modifier = Modifier
+                    .size(24.dp, 14.dp)
+                    .padding(top = 4.dp)
+                    .align(CenterHorizontally),
             )
-            Text(
-                text = stringResource(sheetUi.stateText),
-                style = MaterialTheme.typography.h5,
-                modifier = Modifier.padding(start = 16.dp),
-            )
-        }
-        ProgressDivider(state)
-        val colorControlNormal = MaterialTheme.colors.onSurface.copy(alpha = 0.12f)
-        if (state is ShareUiState.Sharing) {
-            StyledLegacyText(
-                id = R.string.share_onion_intro,
-                modifier = Modifier.padding(top = 16.dp, start = 16.dp, end = 16.dp),
-            )
-            Row(modifier = Modifier.padding(16.dp)) {
-                SelectionContainer(
-                    modifier = Modifier
-                        .weight(1f)
-                        .padding(end = 8.dp),
-                ) {
-                    Text(state.onionAddress, fontFamily = Monospace)
-                }
-                val clipBoardLabel = stringResource(R.string.clipboard_onion_service_label)
-                val ctx = LocalContext.current
-                val clipboard = ctx.getSystemService(CLIPBOARD_SERVICE) as ClipboardManager
-                Button(
-                    onClick = {
-                        val clip = ClipData.newPlainText(clipBoardLabel, state.onionAddress)
-                        clipboard.setPrimaryClip(clip)
-                        Toast.makeText(ctx, R.string.clipboard_onion_service_copied, LENGTH_SHORT)
-                            .show()
-                    },
-                    colors = ButtonDefaults.buttonColors(
-                        backgroundColor = MaterialTheme.colors.surface,
-                        contentColor = MaterialTheme.colors.OnionBlue,
-                    ),
-                    border = BorderStroke(1.dp, colorControlNormal),
-                    shape = RoundedCornerShape(32.dp),
-                    modifier = Modifier
-                        .align(CenterVertically)
-                        .size(48.dp)
-                ) {
-                    Icon(
-                        imageVector = Icons.Filled.ContentCopy,
-                        contentDescription = null,
-                        modifier = Modifier.requiredSize(24.dp),
-                    )
-                }
+            val topPadding = if (state.collapsableSheet) 0.dp else 16.dp
+            Row(
+                verticalAlignment = CenterVertically,
+                modifier = Modifier.padding(start = 16.dp, top = topPadding, bottom = 16.dp),
+            ) {
+                Icon(
+                    imageVector = sheetUi.indicatorIcon,
+                    tint = sheetUi.indicatorColor,
+                    contentDescription = null,
+                    modifier = Modifier.size(16.dp),
+                )
+                Text(
+                    text = stringResource(sheetUi.stateText),
+                    style = MaterialTheme.typography.h5,
+                    modifier = Modifier.padding(start = 16.dp),
+                )
             }
-            Divider(thickness = 2.dp)
-        }
-        Button(
-            onClick = onSheetButtonClicked,
-            colors = if (state is ShareUiState.Sharing) {
-                ButtonDefaults.buttonColors(contentColor = MaterialTheme.colors.OnionRed,
-                    backgroundColor = MaterialTheme.colors.surface)
-            } else ButtonDefaults.buttonColors(),
-            border = if (state is ShareUiState.Sharing) {
-                BorderStroke(1.dp, colorControlNormal)
-            } else null,
-            shape = RoundedCornerShape(32.dp),
-            modifier = Modifier
-                .padding(16.dp)
-                .fillMaxWidth(),
-        ) {
-            Text(
-                text = stringResource(sheetUi.buttonText),
-                fontSize = 16.sp,
-                fontStyle = if (state is ShareUiState.Starting) Italic else null,
-                modifier = Modifier.padding(8.dp)
-            )
+            ProgressDivider(state)
+            val colorControlNormal = MaterialTheme.colors.onSurface.copy(alpha = 0.12f)
+            if (state is ShareUiState.Sharing) {
+                StyledLegacyText(
+                    id = R.string.share_onion_intro,
+                    modifier = Modifier.padding(top = 16.dp, start = 16.dp, end = 16.dp),
+                )
+                Row(modifier = Modifier.padding(16.dp)) {
+                    SelectionContainer(
+                        modifier = Modifier
+                            .weight(1f)
+                            .padding(end = 8.dp),
+                    ) {
+                        Text(state.onionAddress, fontFamily = Monospace)
+                    }
+                    val clipBoardLabel = stringResource(R.string.clipboard_onion_service_label)
+                    val ctx = LocalContext.current
+                    val clipboard = ctx.getSystemService(CLIPBOARD_SERVICE) as ClipboardManager
+                    Button(
+                        onClick = {
+                            val clip = ClipData.newPlainText(clipBoardLabel, state.onionAddress)
+                            clipboard.setPrimaryClip(clip)
+                            Toast.makeText(ctx, R.string.clipboard_onion_service_copied, LENGTH_SHORT)
+                                .show()
+                        },
+                        colors = ButtonDefaults.buttonColors(
+                            backgroundColor = MaterialTheme.colors.surface,
+                            contentColor = MaterialTheme.colors.OnionBlue,
+                        ),
+                        border = BorderStroke(1.dp, colorControlNormal),
+                        shape = RoundedCornerShape(32.dp),
+                        modifier = Modifier
+                            .align(CenterVertically)
+                            .size(48.dp)
+                    ) {
+                        Icon(
+                            imageVector = Icons.Filled.ContentCopy,
+                            contentDescription = null,
+                            modifier = Modifier.requiredSize(24.dp),
+                        )
+                    }
+                }
+                Divider(thickness = 2.dp)
+            }
+            Button(
+                onClick = onSheetButtonClicked,
+                colors = if (state is ShareUiState.Sharing) {
+                    ButtonDefaults.buttonColors(contentColor = MaterialTheme.colors.OnionRed,
+                        backgroundColor = MaterialTheme.colors.surface)
+                } else ButtonDefaults.buttonColors(),
+                border = if (state is ShareUiState.Sharing) {
+                    BorderStroke(1.dp, colorControlNormal)
+                } else null,
+                shape = RoundedCornerShape(32.dp),
+                modifier = Modifier
+                    .padding(16.dp)
+                    .fillMaxWidth(),
+            ) {
+                Text(
+                    text = stringResource(sheetUi.buttonText),
+                    fontSize = 16.sp,
+                    fontStyle = if (state is ShareUiState.Starting) Italic else null,
+                    modifier = Modifier.padding(8.dp)
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/org/onionshare/android/ui/theme/Color.kt
+++ b/app/src/main/java/org/onionshare/android/ui/theme/Color.kt
@@ -12,6 +12,7 @@ val RedLight = Color(0xFFFF0000)
 val RedDark = Color(0xFFF17165)
 val Grey = Color(0xFF626262)
 val Error = Color(0xFFD24141)
+val DarkShadow = Color(0x32000000)
 
 val IndicatorReady = Color.Gray
 val IndicatorStarting = Color(0xFFEE9A38)


### PR DESCRIPTION
Adds shadow to modal bottom sheet: [issue #41](https://github.com/onionshare/onionshare-android/issues/41)


<img width="319" alt="image" src="https://user-images.githubusercontent.com/7727498/162537037-bec29315-4225-4574-8d6a-6b9fbd5ebb65.png">


<img width="319" alt="image" src="https://user-images.githubusercontent.com/7727498/162537072-aae068b6-c3e6-462d-9a90-164c9c465644.png">
