### PR TITLE
Show starting state in notification

### DIFF
--- a/app/src/main/java/org/onionshare/android/ShareManager.kt
+++ b/app/src/main/java/org/onionshare/android/ShareManager.kt
@@ -26,6 +26,7 @@ import org.onionshare.android.server.SendPage
 import org.onionshare.android.server.WebserverManager
 import org.onionshare.android.tor.TorManager
 import org.onionshare.android.tor.TorState
+import org.onionshare.android.ui.OnionNotificationManager
 import org.onionshare.android.ui.share.ShareUiState
 import org.slf4j.LoggerFactory.getLogger
 import java.io.IOException
@@ -40,6 +41,7 @@ class ShareManager @Inject constructor(
     private val torManager: TorManager,
     private val webserverManager: WebserverManager,
     private val fileManager: FileManager,
+    private val notificationManager: OnionNotificationManager,
 ) {
 
     private val _shareState = MutableStateFlow<ShareUiState>(ShareUiState.NoFiles)
@@ -166,7 +168,10 @@ class ShareManager @Inject constructor(
         sharing: ShareUiState.Sharing,
     ) = withContext(Dispatchers.IO) {
         when (state) {
-            WebserverManager.State.STARTED -> _shareState.value = sharing
+            WebserverManager.State.STARTED -> {
+                _shareState.value = sharing
+                notificationManager.onSharing()
+            }
             WebserverManager.State.SHOULD_STOP -> stopSharing(complete = true)
             // Stopping again could cause a harmless double stop,
             // but ensures state update when webserver stops unexpectedly.

--- a/app/src/main/java/org/onionshare/android/ui/OnionNotificationManager.kt
+++ b/app/src/main/java/org/onionshare/android/ui/OnionNotificationManager.kt
@@ -33,12 +33,24 @@ class OnionNotificationManager @Inject constructor(
     }
 
     fun getForegroundNotification(): Notification {
+        val title = app.getText(R.string.starting_notification_title)
+        val text = app.getText(R.string.starting_notification_text)
+        return getNotification(title, text)
+    }
+
+    fun onSharing() {
+        val n = getNotification(app.getText(R.string.sharing_notification_title))
+        nm.notify(NOTIFICATION_ID, n)
+    }
+
+    private fun getNotification(title: CharSequence, text: CharSequence? = null): Notification {
         val pendingIntent: PendingIntent = Intent(app, MainActivity::class.java).let { i ->
             val pendingFlags = if (SDK_INT < 23) 0 else FLAG_IMMUTABLE
             PendingIntent.getActivity(app, 0, i, pendingFlags)
         }
         return NotificationCompat.Builder(app, CHANNEL_ID)
-            .setContentTitle(app.getText(R.string.sharing_notification_title))
+            .setContentTitle(title)
+            .apply { if (!text.isNullOrBlank()) setContentText(text) }
             .setSmallIcon(R.drawable.ic_notification)
             .setColor(getColor(app, R.color.purple_onion_light))
             .setContentIntent(pendingIntent)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -28,6 +28,8 @@
         <item quantity="other">%1$d items, %2$s</item>
     </plurals>
     <string name="sharing_channel_name">File sharing notification</string>
+    <string name="starting_notification_title">Publishing files…</string>
+    <string name="starting_notification_text">This may take some time.</string>
     <string name="sharing_notification_title">Currently sharing files</string>
     <string name="share_error_snackbar_text">Could not start OnionShare</string>
     <string name="share_error_file_snackbar_text">Could not open %s. Removed.</string>


### PR DESCRIPTION
When starting takes a long time, it can be useful to show that files are not yet published.

Fixes #44