### PR TITLE
Catch SecurityException when releasing Uri permission

### DIFF
--- a/app/src/main/java/org/onionshare/android/ShareManager.kt
+++ b/app/src/main/java/org/onionshare/android/ShareManager.kt
@@ -211,7 +211,11 @@ class ShareManager @Inject constructor(
 
     private fun SendFile.releaseUriPermission() {
         val contentResolver = app.applicationContext.contentResolver
-        contentResolver.releasePersistableUriPermission(uri, FLAG_GRANT_READ_URI_PERMISSION)
+        try {
+            contentResolver.releasePersistableUriPermission(uri, FLAG_GRANT_READ_URI_PERMISSION)
+        } catch (e: SecurityException) {
+            LOG.warn("Error releasing PersistableUriPermission", e)
+        }
     }
 
 }


### PR DESCRIPTION
There doesn't seem to be much we can do here otherwise.

Fixes #50 