### PR TITLE
Add settings for custom bridges

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -97,7 +97,9 @@ dependencies {
     implementation "androidx.compose.material:material-icons-extended:$compose_version"
     implementation "androidx.compose.ui:ui-tooling-preview:$compose_version"
     implementation "androidx.navigation:navigation-compose:2.5.2"
+    implementation "androidx.hilt:hilt-navigation-compose:1.0.0"
     implementation "androidx.profileinstaller:profileinstaller:1.2.0"
+    implementation "androidx.security:security-crypto:1.1.0-alpha03"
 
     implementation "com.google.dagger:hilt-android:$hilt_version"
     kapt "com.google.dagger:hilt-compiler:$hilt_version"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,6 +12,8 @@
     <application
         android:name=".OnionShareApp"
         android:allowBackup="false"
+        android:dataExtractionRules="@xml/data_extraction_rules"
+        android:fullBackupContent="@xml/backup_descriptor"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher"

--- a/app/src/main/java/org/onionshare/android/tor/AndroidLocationUtils.kt
+++ b/app/src/main/java/org/onionshare/android/tor/AndroidLocationUtils.kt
@@ -1,0 +1,53 @@
+package org.onionshare.android.tor
+
+import android.annotation.SuppressLint
+import android.app.Application
+import android.content.Context
+import android.telephony.TelephonyManager
+import androidx.core.content.ContextCompat.getSystemService
+import org.slf4j.LoggerFactory.getLogger
+import java.util.Locale
+import java.util.Locale.getAvailableLocales
+import javax.inject.Inject
+
+class AndroidLocationUtils @Inject constructor(app: Application) {
+
+    companion object {
+        private val LOG = getLogger(AndroidLocationUtils::class.java)
+    }
+
+    private val appContext: Context = app.applicationContext
+
+    val currentCountryName: String
+        get() = getAvailableLocales().find { locale ->
+            locale.country.equals(currentCountryIso, ignoreCase = true)
+        }?.displayCountry ?: currentCountryIso
+
+    /**
+     * This guesses the current country from the first of these sources that
+     * succeeds (also in order of likelihood of being correct):
+     *
+     *  * Phone network. This works even when no SIM card is inserted, or a foreign SIM card is inserted.
+     *  * SIM card. This is only an heuristic and assumes the user is not roaming.
+     *  * User locale. This is an even worse heuristic.
+     *
+     * Note: this is very similar to [this API](https://android.googlesource.com/platform/frameworks/base/+/cd92588%5E/location/java/android/location/CountryDetector.java)
+     * except it seems that Google doesn't want us to use it for some reason -
+     * both that class and `Context.COUNTRY_CODE` are annotated `@hide`.
+     */
+    @get:SuppressLint("DefaultLocale")
+    val currentCountryIso: String
+        get() {
+            var countryCode: String? = countryFromPhoneNetwork
+            if (!countryCode.isNullOrEmpty()) return countryCode.uppercase(Locale.getDefault())
+            LOG.info("Falling back to SIM card country")
+            countryCode = countryFromSimCard
+            if (!countryCode.isNullOrEmpty()) return countryCode.uppercase(Locale.getDefault())
+            LOG.info("Falling back to user-defined locale")
+            return Locale.getDefault().country
+        }
+    private val countryFromPhoneNetwork: String?
+        get() = getSystemService(appContext, TelephonyManager::class.java)?.networkCountryIso
+    private val countryFromSimCard: String?
+        get() = getSystemService(appContext, TelephonyManager::class.java)?.simCountryIso
+}

--- a/app/src/main/java/org/onionshare/android/ui/CopyButton.kt
+++ b/app/src/main/java/org/onionshare/android/ui/CopyButton.kt
@@ -1,0 +1,54 @@
+package org.onionshare.android.ui
+
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
+import android.widget.Toast
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.requiredSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Button
+import androidx.compose.material.ButtonDefaults
+import androidx.compose.material.Icon
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ContentCopy
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import org.onionshare.android.R
+import org.onionshare.android.ui.theme.OnionBlue
+
+@Composable
+fun CopyButton(toCopy: String, clipBoardLabel: String) {
+    val ctx = LocalContext.current
+    val clipboard = ctx.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+    val colorControlNormal = MaterialTheme.colors.onSurface.copy(alpha = 0.12f)
+    Button(
+        onClick = {
+            val clip = ClipData.newPlainText(clipBoardLabel, toCopy)
+            clipboard.setPrimaryClip(clip)
+            Toast.makeText(ctx, R.string.clipboard_onion_service_copied, Toast.LENGTH_SHORT)
+                .show()
+        },
+        colors = ButtonDefaults.buttonColors(
+            backgroundColor = MaterialTheme.colors.surface,
+            contentColor = MaterialTheme.colors.OnionBlue,
+        ),
+        border = BorderStroke(1.dp, colorControlNormal),
+        shape = RoundedCornerShape(32.dp),
+        elevation = ButtonDefaults.elevation(
+            defaultElevation = 0.dp,
+        ),
+        modifier = Modifier
+            .size(48.dp)
+    ) {
+        Icon(
+            imageVector = Icons.Filled.ContentCopy,
+            contentDescription = null,
+            modifier = Modifier.requiredSize(24.dp),
+        )
+    }
+}

--- a/app/src/main/java/org/onionshare/android/ui/MainUi.kt
+++ b/app/src/main/java/org/onionshare/android/ui/MainUi.kt
@@ -6,10 +6,16 @@ import androidx.compose.runtime.Composable
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import org.onionshare.android.ui.settings.MyBridgesUi
+import org.onionshare.android.ui.settings.SettingsTorUi
+import org.onionshare.android.ui.settings.SettingsUi
 import org.onionshare.android.ui.share.ShareUiSetup
 import org.onionshare.android.ui.theme.OnionshareTheme
 
 const val ROUTE_SHARE = "share"
+const val ROUTE_SETTINGS = "settings"
+const val ROUTE_SETTINGS_TOR = "settings-tor"
+const val ROUTE_SETTINGS_MY_BRIDGES = "settings-myBridges"
 const val ROUTE_ABOUT = "about"
 
 @Composable
@@ -19,6 +25,15 @@ fun MainUi(viewModel: MainViewModel) = OnionshareTheme {
         NavHost(navController = navController, startDestination = ROUTE_SHARE) {
             composable(ROUTE_SHARE) {
                 ShareUiSetup(navController, viewModel)
+            }
+            composable(ROUTE_SETTINGS) {
+                SettingsUi(navController)
+            }
+            composable(ROUTE_SETTINGS_TOR) {
+                SettingsTorUi(navController)
+            }
+            composable(ROUTE_SETTINGS_MY_BRIDGES) {
+                MyBridgesUi(navController)
             }
             composable(ROUTE_ABOUT) {
                 AboutUi(navController)

--- a/app/src/main/java/org/onionshare/android/ui/MainViewModel.kt
+++ b/app/src/main/java/org/onionshare/android/ui/MainViewModel.kt
@@ -11,12 +11,14 @@ import org.briarproject.android.dontkillmelib.DozeUtils.needsDozeWhitelisting
 import org.onionshare.android.ShareManager
 import org.onionshare.android.files.FileManager
 import org.onionshare.android.server.SendFile
+import org.onionshare.android.ui.settings.SettingsManager
 import org.onionshare.android.ui.share.ShareUiState
 import javax.inject.Inject
 
 @HiltViewModel
 class MainViewModel @Inject constructor(
     app: Application,
+    val settingsManager: SettingsManager,
     private val shareManager: ShareManager,
     private val fileManager: FileManager,
 ) : AndroidViewModel(app) {

--- a/app/src/main/java/org/onionshare/android/ui/ShareButton.kt
+++ b/app/src/main/java/org/onionshare/android/ui/ShareButton.kt
@@ -1,0 +1,38 @@
+package org.onionshare.android.ui
+
+import android.content.Intent
+import android.content.Intent.ACTION_SEND
+import android.content.Intent.EXTRA_TEXT
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Share
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import org.onionshare.android.R
+import org.onionshare.android.ui.theme.OnionBlue
+
+@Composable
+fun ShareButton(text: String, modifier: Modifier = Modifier) {
+    val context = LocalContext.current
+    IconButton(
+        modifier = modifier,
+        onClick = {
+            val sendIntent = Intent().apply {
+                action = ACTION_SEND
+                putExtra(EXTRA_TEXT, text)
+                type = "text/plain"
+            }
+            context.startActivity(Intent.createChooser(sendIntent, null))
+        },
+    ) {
+        Icon(
+            imageVector = Icons.Filled.Share,
+            contentDescription = stringResource(R.string.share),
+            tint = MaterialTheme.colors.OnionBlue,
+        )
+    }
+}

--- a/app/src/main/java/org/onionshare/android/ui/settings/MyBridgesUi.kt
+++ b/app/src/main/java/org/onionshare/android/ui/settings/MyBridgesUi.kt
@@ -1,0 +1,138 @@
+package org.onionshare.android.ui.settings
+
+import androidx.compose.foundation.layout.Arrangement.SpaceBetween
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material.Card
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Surface
+import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment.Companion.Center
+import androidx.compose.ui.Alignment.Companion.CenterVertically
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.navigation.NavHostController
+import org.onionshare.android.R
+import org.onionshare.android.ui.AboutActionBar
+import org.onionshare.android.ui.MainViewModel
+import org.onionshare.android.ui.ShareButton
+import org.onionshare.android.ui.theme.OnionshareTheme
+
+@Composable
+fun MyBridgesUi(
+    navController: NavHostController,
+    viewModel: MainViewModel = hiltViewModel(),
+) {
+    val settingsManager = viewModel.settingsManager
+    Scaffold(topBar = {
+        AboutActionBar(navController, R.string.settings_tor_my_bridges_title)
+    }) { innerPadding ->
+        MyBridgesUiContent(
+            bridges = settingsManager.customBridges.value,
+            onBridgeRemoved = { settingsManager.removeCustomBridge(it) },
+            modifier = Modifier.padding(innerPadding),
+        )
+    }
+}
+
+@Composable
+fun MyBridgesUiContent(
+    bridges: List<String>,
+    onBridgeRemoved: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    if (bridges.isEmpty()) Box(modifier = Modifier.fillMaxSize()) {
+        Text(
+            modifier = Modifier.align(Center),
+            text = stringResource(R.string.settings_tor_bridges_none),
+            style = MaterialTheme.typography.h5,
+        )
+    } else {
+        val scrollState = rememberLazyListState()
+        LazyColumn(
+            modifier = modifier,
+            state = scrollState,
+        ) {
+            items(bridges) {
+                BridgeLineUi(it) {
+                    onBridgeRemoved(it)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun BridgeLineUi(bridge: String, onDelete: () -> Unit) {
+    Card(
+        modifier = Modifier
+            .padding(horizontal = 16.dp)
+            .padding(top = 16.dp, bottom = 1.dp),
+    ) {
+        Row(
+            modifier = Modifier
+                .padding(8.dp)
+                .height(IntrinsicSize.Min),
+            verticalAlignment = CenterVertically,
+        ) {
+            Text(
+                modifier = Modifier.weight(1f),
+                text = bridge,
+                style = MaterialTheme.typography.body1,
+                fontFamily = FontFamily.Monospace,
+            )
+            Column(
+                modifier = Modifier.fillMaxHeight(),
+                verticalArrangement = SpaceBetween,
+            ) {
+                ShareButton(bridge)
+                IconButton(
+                    onClick = onDelete,
+                ) {
+                    Icon(
+                        imageVector = Icons.Filled.Delete,
+                        contentDescription = stringResource(R.string.delete),
+                        tint = MaterialTheme.colors.onSurface.copy(alpha = 0.65f)
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun MyBridgesPreview() = OnionshareTheme {
+    Surface(color = MaterialTheme.colors.background) {
+        MyBridgesUiContent(
+            bridges = listOf(
+                "obfs4 178.238.237.63:1443 2818B19A83611C927F3D1A054432A730763D571D " +
+                    "cert=BKOIE8C7Bz4dSxIH0W91GfdXq1V3uDnPBb/9rwjWfrPGXxlh16nJ+zpENvb84JlP6pG2IA iat-mode=0",
+                "obfs4 92.37.149.198:443 B66921924E47BB9D4FD582DE0671F6AE9975598E " +
+                    "cert=UwbBnGYeVRoxhCA5+wxd2tRgS7BimvT3ZjKDec4HE5gS0Wc5w4QIbEO4gx6do/FAcJZ0Jg iat-mode=0",
+                "obfs4 201.61.207.126:2439 6F059771EFD2EE8649C2CCEF41407AEBD82B1E4C " +
+                    "cert=caVSQBW9+duFx52XC51Sgoc6GvPlCfdSdYWvMYdlR5TQDYzCOEtGy+qE/s7QHsyrX2tFCQ iat-mode=0",
+            ),
+            onBridgeRemoved = {},
+        )
+    }
+}

--- a/app/src/main/java/org/onionshare/android/ui/settings/SettingsManager.kt
+++ b/app/src/main/java/org/onionshare/android/ui/settings/SettingsManager.kt
@@ -1,0 +1,58 @@
+package org.onionshare.android.ui.settings
+
+import android.app.Application
+import androidx.compose.runtime.State
+import androidx.compose.runtime.mutableStateOf
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV
+import androidx.security.crypto.EncryptedSharedPreferences.PrefValueEncryptionScheme
+import androidx.security.crypto.MasterKey
+import androidx.security.crypto.MasterKey.KeyScheme.AES256_GCM
+import org.onionshare.android.tor.AndroidLocationUtils
+import javax.inject.Inject
+import javax.inject.Singleton
+
+private const val PREF_AUTO_BRIDGES = "autoBridges"
+private const val PREF_CUSTOM_BRIDGES = "customBridges"
+
+@Singleton
+class SettingsManager @Inject constructor(
+    app: Application,
+    private val locationUtils: AndroidLocationUtils,
+) {
+    private val masterKeyAlias = MasterKey.Builder(app).setKeyScheme(AES256_GCM).build()
+    private val sharedPreferences = EncryptedSharedPreferences.create(app, "secret_shared_prefs", masterKeyAlias,
+        AES256_SIV, PrefValueEncryptionScheme.AES256_GCM)
+
+    private val _automaticBridges = mutableStateOf(sharedPreferences.getBoolean(PREF_AUTO_BRIDGES, true))
+    val automaticBridges: State<Boolean> = _automaticBridges
+
+    private val _customBridges =
+        mutableStateOf<List<String>>(sharedPreferences.getStringSet(PREF_CUSTOM_BRIDGES, emptySet())!!.toList())
+    val customBridges: State<List<String>> = _customBridges
+
+    val currentCountry: String get() = locationUtils.currentCountryName
+
+    fun setAutomaticBridges(enabled: Boolean) {
+        sharedPreferences.edit().putBoolean(PREF_AUTO_BRIDGES, enabled).apply()
+        _automaticBridges.value = enabled
+    }
+
+    fun addCustomBridges(text: String): Int {
+        // TODO validate
+        val set = customBridges.value.toSet() + text.split('\n').filter { it.isNotBlank() }
+        updateCustomBridges(set)
+        return set.size
+    }
+
+    fun removeCustomBridge(bridge: String) {
+        val set = customBridges.value.toMutableSet().apply { remove(bridge) }
+        updateCustomBridges(set)
+    }
+
+    private fun updateCustomBridges(set: Set<String>) {
+        sharedPreferences.edit().putStringSet(PREF_CUSTOM_BRIDGES, set).apply()
+        _customBridges.value = set.toList()
+    }
+
+}

--- a/app/src/main/java/org/onionshare/android/ui/settings/SettingsTorUi.kt
+++ b/app/src/main/java/org/onionshare/android/ui/settings/SettingsTorUi.kt
@@ -110,8 +110,7 @@ fun SettingsTorUiContent(
             modifier = Modifier
                 .padding(horizontal = 16.dp)
                 .padding(top = 16.dp, bottom = 8.dp),
-            text = stringResource(R.string.settings_tor_intro) + " " +
-                stringResource(R.string.settings_tor_automatic_info),
+            text = stringResource(R.string.settings_tor_intro),
             style = MaterialTheme.typography.body2,
         )
         RadioPreference(

--- a/app/src/main/java/org/onionshare/android/ui/settings/SettingsTorUi.kt
+++ b/app/src/main/java/org/onionshare/android/ui/settings/SettingsTorUi.kt
@@ -1,0 +1,287 @@
+package org.onionshare.android.ui.settings
+
+import android.content.Context
+import android.content.Intent
+import android.content.Intent.ACTION_VIEW
+import android.net.Uri
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.OutlinedTextField
+import androidx.compose.material.RadioButton
+import androidx.compose.material.Scaffold
+import androidx.compose.material.SnackbarDuration
+import androidx.compose.material.Surface
+import androidx.compose.material.Text
+import androidx.compose.material.TextButton
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ContentPaste
+import androidx.compose.material.rememberScaffoldState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment.Companion.CenterVertically
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.navigation.NavHostController
+import kotlinx.coroutines.launch
+import org.onionshare.android.R
+import org.onionshare.android.ui.AboutActionBar
+import org.onionshare.android.ui.MainViewModel
+import org.onionshare.android.ui.ROUTE_SETTINGS_MY_BRIDGES
+import org.onionshare.android.ui.ShareButton
+import org.onionshare.android.ui.theme.OnionBlue
+import org.onionshare.android.ui.theme.OnionshareTheme
+import kotlin.random.Random
+
+private const val BRIDGE_DB = "https://bridges.torproject.org"
+
+@Composable
+fun SettingsTorUi(
+    navController: NavHostController,
+    viewModel: MainViewModel = hiltViewModel(),
+) {
+    val context = LocalContext.current
+    val settingsManager = viewModel.settingsManager
+    val scaffoldState = rememberScaffoldState()
+    val coroutineScope = rememberCoroutineScope()
+    Scaffold(
+        scaffoldState = scaffoldState,
+        topBar = {
+            AboutActionBar(navController, R.string.settings_tor_title)
+        }
+    ) { innerPadding ->
+        SettingsTorUiContent(
+            country = settingsManager.currentCountry,
+            automaticBridges = settingsManager.automaticBridges.value,
+            numberOfCustomBridges = settingsManager.customBridges.value.size,
+            onMyBridgesClicked = { navController.navigate(ROUTE_SETTINGS_MY_BRIDGES) },
+            onAutomaticBridgesChanged = { settingsManager.setAutomaticBridges(it) },
+            onBridgesAdded = {
+                val numBridgesAdded = settingsManager.addCustomBridges(it)
+                coroutineScope.launch {
+                    scaffoldState.snackbarHostState.showSnackbar(
+                        message = getBridgeNumberString(context, numBridgesAdded),
+                        duration = SnackbarDuration.Short,
+                    )
+                }
+            },
+            modifier = Modifier.padding(innerPadding),
+        )
+    }
+}
+
+@Composable
+fun SettingsTorUiContent(
+    country: String,
+    automaticBridges: Boolean,
+    numberOfCustomBridges: Int,
+    onMyBridgesClicked: () -> Unit,
+    onAutomaticBridgesChanged: (Boolean) -> Unit,
+    onBridgesAdded: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val scrollableState = rememberScrollState()
+    Column(modifier = modifier.verticalScroll(scrollableState)
+    ) {
+        Text(
+            modifier = Modifier
+                .padding(horizontal = 16.dp)
+                .padding(top = 16.dp, bottom = 8.dp),
+            text = stringResource(R.string.settings_tor_intro) + " " +
+                stringResource(R.string.settings_tor_automatic_info),
+            style = MaterialTheme.typography.body2,
+        )
+        RadioPreference(
+            title = stringResource(R.string.settings_tor_automatic),
+            summary = country,
+            selected = automaticBridges,
+        ) {
+            onAutomaticBridgesChanged(true)
+        }
+        RadioPreference(
+            title = stringResource(R.string.settings_tor_bridges_title),
+            summary = getBridgeNumberString(LocalContext.current, numberOfCustomBridges),
+            selected = !automaticBridges,
+        ) {
+            onAutomaticBridgesChanged(false)
+        }
+        if (!automaticBridges) CustomBridgesUi(
+            numberOfCustomBridges = numberOfCustomBridges,
+            onMyBridgesClicked = onMyBridgesClicked,
+            onBridgesAdded = onBridgesAdded,
+        )
+    }
+}
+
+@Composable
+fun CustomBridgesUi(
+    numberOfCustomBridges: Int,
+    onMyBridgesClicked: () -> Unit,
+    onBridgesAdded: (String) -> Unit,
+) {
+    val context = LocalContext.current
+    Preference(
+        title = stringResource(R.string.settings_tor_my_bridges_title),
+        summary = getBridgeNumberString(context, numberOfCustomBridges),
+    ) { onMyBridgesClicked() }
+    Text(
+        modifier = Modifier
+            .padding(horizontal = 16.dp),
+        text = stringResource(R.string.settings_tor_bridges_intro),
+        style = MaterialTheme.typography.body2,
+    )
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp),
+        verticalAlignment = CenterVertically,
+    ) {
+        Text(
+            modifier = Modifier
+                .clickable {
+                    val linkIntent = Intent().apply {
+                        action = ACTION_VIEW
+                        data = Uri.parse(BRIDGE_DB)
+                    }
+                    context.startActivity(Intent.createChooser(linkIntent, null))
+                }
+                .weight(1f)
+                .padding(top = 8.dp, bottom = 8.dp, end = 8.dp),
+            text = BRIDGE_DB,
+            fontFamily = FontFamily.Monospace,
+            color = MaterialTheme.colors.OnionBlue,
+        )
+        ShareButton(BRIDGE_DB)
+    }
+    var textState by remember { mutableStateOf(TextFieldValue("")) }
+    OutlinedTextField(
+        modifier = Modifier
+            .padding(horizontal = 16.dp)
+            .padding(top = 8.dp)
+            .fillMaxWidth()
+            .heightIn(min = 128.dp),
+        value = textState,
+        onValueChange = { textState = it },
+        singleLine = false,
+    )
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        val clipboardManager = LocalClipboardManager.current
+        IconButton(
+            modifier = Modifier.padding(horizontal = 8.dp),
+            onClick = {
+                clipboardManager.getText()?.let {
+                    textState = TextFieldValue(it, selection = TextRange(it.length))
+                }
+            },
+        ) {
+            Icon(
+                imageVector = Icons.Filled.ContentPaste,
+                contentDescription = stringResource(R.string.paste),
+                tint = MaterialTheme.colors.onSurface.copy(alpha = 0.65f),
+            )
+        }
+        Spacer(modifier = Modifier.weight(1f))
+        TextButton(
+            modifier = Modifier.padding(horizontal = 16.dp),
+            onClick = { textState = TextFieldValue("") },
+            enabled = textState.text.isNotBlank(),
+        ) {
+            Text(stringResource(R.string.cancel))
+        }
+        TextButton(
+            modifier = Modifier.padding(horizontal = 16.dp),
+            onClick = {
+                onBridgesAdded(textState.text)
+                textState = TextFieldValue("")
+            },
+            enabled = textState.text.isNotBlank(),
+        ) {
+            Text(stringResource(R.string.add))
+        }
+    }
+}
+
+@Composable
+fun RadioPreference(
+    title: String,
+    summary: String,
+    selected: Boolean,
+    onSelected: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .selectable(
+                enabled = !selected,
+                selected = selected,
+                onClick = onSelected,
+            )
+            .padding(vertical = 8.dp)
+            .padding(start = 4.dp, end = 16.dp),
+        verticalAlignment = CenterVertically,
+    ) {
+        RadioButton(
+            selected = selected,
+            onClick = onSelected,
+        )
+        Column(Modifier.padding(start = 8.dp)) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.body1,
+            )
+            Text(
+                text = summary,
+                style = MaterialTheme.typography.body2,
+                modifier = Modifier.alpha(0.65f)
+            )
+        }
+    }
+}
+
+fun getBridgeNumberString(context: Context, num: Int): String {
+    return if (num == 0) {
+        context.getString(R.string.settings_tor_bridges_none)
+    } else {
+        context.resources.getQuantityString(R.plurals.settings_tor_bridges_number, num, num)
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun SettingsTorPreview() = OnionshareTheme {
+    Surface(color = MaterialTheme.colors.background) {
+        SettingsTorUiContent(
+            country = "United States",
+            automaticBridges = false,
+            numberOfCustomBridges = Random.nextInt(0, 2),
+            onMyBridgesClicked = {},
+            onAutomaticBridgesChanged = {},
+            onBridgesAdded = {},
+        )
+    }
+}

--- a/app/src/main/java/org/onionshare/android/ui/settings/SettingsUi.kt
+++ b/app/src/main/java/org/onionshare/android/ui/settings/SettingsUi.kt
@@ -61,7 +61,7 @@ fun Preference(
 ) {
     Column(modifier = Modifier
         .fillMaxWidth()
-        .clickable { onClick() }
+        .clickable(onClick = onClick)
         .padding(16.dp)
     ) {
         Column {

--- a/app/src/main/java/org/onionshare/android/ui/settings/SettingsUi.kt
+++ b/app/src/main/java/org/onionshare/android/ui/settings/SettingsUi.kt
@@ -1,0 +1,87 @@
+package org.onionshare.android.ui.settings
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Surface
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.rememberNavController
+import org.onionshare.android.R
+import org.onionshare.android.ui.AboutActionBar
+import org.onionshare.android.ui.MainViewModel
+import org.onionshare.android.ui.ROUTE_SETTINGS_TOR
+import org.onionshare.android.ui.theme.OnionshareTheme
+
+@Composable
+fun SettingsUi(
+    navController: NavHostController,
+    viewModel: MainViewModel = hiltViewModel(),
+) {
+    val automatic = viewModel.settingsManager.automaticBridges.value
+    Scaffold(topBar = {
+        AboutActionBar(navController, R.string.settings_title)
+    }) { innerPadding ->
+        val scrollableState = rememberScrollState()
+        Column(modifier = Modifier
+            .padding(innerPadding)
+            .verticalScroll(scrollableState)
+        ) {
+            Preference(
+                title = stringResource(R.string.settings_tor_title),
+                summary = if (automatic) {
+                    stringResource(R.string.settings_tor_automatic)
+                } else {
+                    stringResource(R.string.settings_tor_bridges_title)
+                },
+            ) {
+                navController.navigate(ROUTE_SETTINGS_TOR)
+            }
+        }
+    }
+}
+
+@Composable
+fun Preference(
+    title: String,
+    summary: String,
+    onClick: () -> Unit,
+) {
+    Column(modifier = Modifier
+        .fillMaxWidth()
+        .clickable { onClick() }
+        .padding(16.dp)
+    ) {
+        Column {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.body1,
+            )
+            Text(
+                text = summary,
+                style = MaterialTheme.typography.body2,
+                modifier = Modifier.alpha(0.65f)
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun SettingsPreview() = OnionshareTheme {
+    Surface(color = MaterialTheme.colors.background) {
+        SettingsUi(rememberNavController())
+    }
+}

--- a/app/src/main/java/org/onionshare/android/ui/share/ShareBottomSheet.kt
+++ b/app/src/main/java/org/onionshare/android/ui/share/ShareBottomSheet.kt
@@ -1,11 +1,6 @@
 package org.onionshare.android.ui.share
 
-import android.content.ClipData
-import android.content.ClipboardManager
-import android.content.Context.CLIPBOARD_SERVICE
 import android.content.res.Configuration.UI_MODE_NIGHT_YES
-import android.widget.Toast
-import android.widget.Toast.LENGTH_SHORT
 import androidx.annotation.StringRes
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.BorderStroke
@@ -15,7 +10,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.requiredSize
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.selection.SelectionContainer
@@ -31,7 +25,6 @@ import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.Circle
-import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.filled.DragHandle
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -45,7 +38,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily.Companion.Monospace
 import androidx.compose.ui.text.font.FontStyle.Companion.Italic
@@ -53,12 +45,12 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import org.onionshare.android.R
+import org.onionshare.android.ui.CopyButton
 import org.onionshare.android.ui.StyledLegacyText
 import org.onionshare.android.ui.theme.Error
 import org.onionshare.android.ui.theme.IndicatorReady
 import org.onionshare.android.ui.theme.IndicatorSharing
 import org.onionshare.android.ui.theme.IndicatorStarting
-import org.onionshare.android.ui.theme.OnionBlue
 import org.onionshare.android.ui.theme.OnionRed
 import org.onionshare.android.ui.theme.OnionshareTheme
 
@@ -148,7 +140,7 @@ fun BottomSheet(state: ShareUiState, onSheetButtonClicked: () -> Unit) {
                 id = R.string.share_onion_intro,
                 modifier = Modifier.padding(top = 16.dp, start = 16.dp, end = 16.dp),
             )
-            Row(modifier = Modifier.padding(16.dp)) {
+            Row(modifier = Modifier.padding(16.dp), verticalAlignment = CenterVertically) {
                 SelectionContainer(
                     modifier = Modifier
                         .weight(1f)
@@ -156,35 +148,10 @@ fun BottomSheet(state: ShareUiState, onSheetButtonClicked: () -> Unit) {
                 ) {
                     Text(state.onionAddress, fontFamily = Monospace)
                 }
-                val clipBoardLabel = stringResource(R.string.clipboard_onion_service_label)
-                val ctx = LocalContext.current
-                val clipboard = ctx.getSystemService(CLIPBOARD_SERVICE) as ClipboardManager
-                Button(
-                    onClick = {
-                        val clip = ClipData.newPlainText(clipBoardLabel, state.onionAddress)
-                        clipboard.setPrimaryClip(clip)
-                        Toast.makeText(ctx, R.string.clipboard_onion_service_copied, LENGTH_SHORT)
-                            .show()
-                    },
-                    colors = ButtonDefaults.buttonColors(
-                        backgroundColor = MaterialTheme.colors.surface,
-                        contentColor = MaterialTheme.colors.OnionBlue,
-                    ),
-                    border = BorderStroke(1.dp, colorControlNormal),
-                    shape = RoundedCornerShape(32.dp),
-                    elevation = ButtonDefaults.elevation(
-                        defaultElevation = 0.dp,
-                    ),
-                    modifier = Modifier
-                        .align(CenterVertically)
-                        .size(48.dp)
-                ) {
-                    Icon(
-                        imageVector = Icons.Filled.ContentCopy,
-                        contentDescription = null,
-                        modifier = Modifier.requiredSize(24.dp),
-                    )
-                }
+                CopyButton(
+                    toCopy = state.onionAddress,
+                    clipBoardLabel = stringResource(R.string.clipboard_onion_service_label),
+                )
             }
             Divider(thickness = 2.dp)
         } else if (state is ShareUiState.Error) {

--- a/app/src/main/java/org/onionshare/android/ui/share/ShareUi.kt
+++ b/app/src/main/java/org/onionshare/android/ui/share/ShareUi.kt
@@ -14,6 +14,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.BottomSheetScaffold
 import androidx.compose.material.BottomSheetState
+import androidx.compose.material.DropdownMenu
+import androidx.compose.material.DropdownMenuItem
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.FloatingActionButton
 import androidx.compose.material.Icon
@@ -26,14 +28,16 @@ import androidx.compose.material.Text
 import androidx.compose.material.TopAppBar
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
-import androidx.compose.material.icons.filled.Info
+import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.rememberBottomSheetScaffoldState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.State
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment.Companion.CenterHorizontally
 import androidx.compose.ui.Alignment.Companion.TopCenter
 import androidx.compose.ui.Modifier
@@ -54,9 +58,11 @@ import androidx.navigation.compose.rememberNavController
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import org.onionshare.android.BuildConfig
 import org.onionshare.android.R
 import org.onionshare.android.server.SendFile
 import org.onionshare.android.ui.ROUTE_ABOUT
+import org.onionshare.android.ui.ROUTE_SETTINGS
 import org.onionshare.android.ui.theme.Fab
 import org.onionshare.android.ui.theme.OnionshareTheme
 import org.onionshare.android.ui.theme.topBar
@@ -150,18 +156,35 @@ private fun getOffsetInDp(offset: State<Float>): Dp {
 fun ActionBar(
     navController: NavHostController,
     @StringRes res: Int,
-) = TopAppBar(
-    backgroundColor = MaterialTheme.colors.topBar,
-    title = { Text(stringResource(res)) },
-    actions = {
-        IconButton(onClick = { navController.navigate(ROUTE_ABOUT) }) {
-            Icon(
-                imageVector = Icons.Filled.Info,
-                contentDescription = stringResource(R.string.about_title),
-            )
-        }
-    },
-)
+) {
+    var showMenu by remember { mutableStateOf(false) }
+    TopAppBar(
+        backgroundColor = MaterialTheme.colors.topBar,
+        title = { Text(stringResource(res)) },
+        actions = {
+            IconButton(onClick = { showMenu = !showMenu }) {
+                Icon(
+                    imageVector = Icons.Default.MoreVert,
+                    contentDescription = stringResource(R.string.menu)
+                )
+            }
+            DropdownMenu(
+                expanded = showMenu,
+                onDismissRequest = { showMenu = false }
+            ) {
+                // TODO remove when bridges work
+                if (BuildConfig.DEBUG) {
+                    DropdownMenuItem(onClick = { navController.navigate(ROUTE_SETTINGS) }) {
+                        Text(stringResource(R.string.settings_title))
+                    }
+                }
+                DropdownMenuItem(onClick = { navController.navigate(ROUTE_ABOUT) }) {
+                    Text(stringResource(R.string.about_title))
+                }
+            }
+        },
+    )
+}
 
 @Composable
 @OptIn(ExperimentalMaterialApi::class)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,6 +2,12 @@
     <string name="app_name">OnionShare (alpha)</string>
 
     <string name="back">Back</string>
+    <string name="menu">Menu</string>
+    <string name="cancel">Cancel</string>
+    <string name="add">Add</string>
+    <string name="share">Share</string>
+    <string name="delete">Delete</string>
+    <string name="paste">Paste</string>
     <string name="add_files_not_supported">Your device does not support adding files</string>
     <string name="unknown">unknown</string>
     <string name="remove">Remove</string>
@@ -53,4 +59,18 @@
     <string name="about_contributor_pm">%s, Project Manager</string>
     <string name="about_contributor_design">%s, Product Designer</string>
     <string name="about_contributing_orgs">Contributing Organizations</string>
+
+    <string name="settings_title">Settings</string>
+    <string name="settings_tor_title">Connecting to Tor</string>
+    <string name="settings_tor_automatic">Automatic based on location</string>
+    <string name="settings_tor_intro">A bridge is a dedicated uncensored route into the Tor network.</string>
+    <string name="settings_tor_automatic_info">Even if Automatic is selected, OnionShare may try to use bridges to connect.</string>
+    <string name="settings_tor_bridges_title">Custom Bridges</string>
+    <string name="settings_tor_bridges_none">None added</string>
+    <plurals name="settings_tor_bridges_number">
+        <item quantity="one">%d bridge added</item>
+        <item quantity="other">%d bridges added</item>
+    </plurals>
+    <string name="settings_tor_bridges_intro">Tap the link below to get bridges. Then paste one or more bridge lines into the field below.</string>
+    <string name="settings_tor_my_bridges_title">My Bridges</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -63,8 +63,7 @@
     <string name="settings_title">Settings</string>
     <string name="settings_tor_title">Connecting to Tor</string>
     <string name="settings_tor_automatic">Automatic based on location</string>
-    <string name="settings_tor_intro">A bridge is a dedicated uncensored route into the Tor network.</string>
-    <string name="settings_tor_automatic_info">Even if Automatic is selected, OnionShare may try to use bridges to connect.</string>
+    <string name="settings_tor_intro">A bridge is a dedicated uncensored route into the Tor network. Even if Automatic is selected, OnionShare may try to use bridges to connect.</string>
     <string name="settings_tor_bridges_title">Custom Bridges</string>
     <string name="settings_tor_bridges_none">None added</string>
     <plurals name="settings_tor_bridges_number">

--- a/app/src/main/res/xml/backup_descriptor.xml
+++ b/app/src/main/res/xml/backup_descriptor.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<full-backup-content>
+    <!-- will not be able to decrypt this, causing crash -->
+    <exclude
+        domain="sharedpref"
+        path="secret_shared_prefs.xml" />
+</full-backup-content>

--- a/app/src/main/res/xml/data_extraction_rules.xml
+++ b/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<data-extraction-rules>
+    <cloud-backup>
+        <exclude
+            domain="sharedpref"
+            path="secret_shared_prefs.xml" />
+    </cloud-backup>
+    <device-transfer>
+        <exclude
+            domain="sharedpref"
+            path="secret_shared_prefs.xml" />
+    </device-transfer>
+</data-extraction-rules>


### PR DESCRIPTION
Adds settings to set custom bridges to Tor. These are only shown in debug builds, because they are not actually functional. This PR is just about the UI. Making use of them in `TorManager` will be done separately.

First part of #39