### PR TITLE
Use a random path to prevent other apps from accessing content

### DIFF
--- a/app/src/main/assets/templates/send.html
+++ b/app/src/main/assets/templates/send.html
@@ -23,7 +23,7 @@
         <div>Total size: <strong>{{ filesize_human }}</strong> {% if is_zipped %} (compressed){%
             endif %}
         </div>
-        <a class="button" href='/download'>Download Files</a>
+        <a class="button" href='{{ content_path }}/download'>Download Files</a>
     </div>
 </header>
 

--- a/app/src/main/java/org/onionshare/android/ShareManager.kt
+++ b/app/src/main/java/org/onionshare/android/ShareManager.kt
@@ -148,7 +148,7 @@ class ShareManager @Inject constructor(
                 // We only create the hidden service after files have been zipped and webserver was started,
                 // so we are in sharing state once the first HS descriptor has been published.
                 notificationManager.onSharing()
-                ShareUiState.Sharing("http://${torState.onion}.onion")
+                ShareUiState.Sharing("http://${torState.onion}.onion/${webserverManager.contentPath}")
             }
 
             TorState.FailedToConnect -> {

--- a/app/src/main/java/org/onionshare/android/ui/share/ShareBottomSheet.kt
+++ b/app/src/main/java/org/onionshare/android/ui/share/ShareBottomSheet.kt
@@ -257,7 +257,7 @@ fun ShareBottomSheetSharingPreview() {
         Surface(color = MaterialTheme.colors.background) {
             BottomSheet(
                 state = ShareUiState.Sharing(
-                    "http://openpravyvc6spbd4flzn4g2iqu4sxzsizbtb5aqec25t76dnoo5w7yd.onion/",
+                    "http://openpravyvc6spbd4flzn4g2iqu4sxzsizbtb5aqec25t76dnoo5w7yd.onion/eW91IGFyZSBhIG5lcmQ7KQ",
                 ),
                 onSheetButtonClicked = {},
             )


### PR DESCRIPTION
The path is the Base64 encoding of 128 bits from SecureRandom. This prevents anyone who doesn't know the path (eg untrusted apps running on localhost) from accessing the content. The root URL now returns a 404 page.

Fixes #104.