### PR TITLE
Change the random content path each time new files are shared

### DIFF
--- a/app/src/main/java/org/onionshare/android/server/WebserverManager.kt
+++ b/app/src/main/java/org/onionshare/android/server/WebserverManager.kt
@@ -54,10 +54,13 @@ class WebserverManager @Inject constructor() {
     private var server: ApplicationEngine? = null
     private val _state = MutableStateFlow<WebServerState>(WebServerState.Stopped(false))
     val state = _state.asStateFlow()
-    val contentPath = getRandomPath()
+    @Volatile
+    var contentPath = ""
+        private set
 
     suspend fun start(sendPage: SendPage): Int {
         _state.value = WebServerState.Starting
+        contentPath = getRandomPath()
         val staticPath = getStaticPath()
         val pathMap = mapOf("static_url_path" to staticPath, "content_path" to contentPath)
         TrafficStats.setThreadStatsTag(0x42)


### PR DESCRIPTION
This protects against a potential attack where the attacker controls another app on the same device as OnionShare, and has also received the URL of one of the user's previous shares. The attacker would then be able to reuse the random content path from the known URL to download future shares via the other app.

Fixes #120