### PR TITLE
ci: signed per-ABI release APKs via GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,31 @@
+version: 2
+updates:
+  # One grouped PR per month — avoids CI spam from Dependabot.
+  - package-ecosystem: gradle
+    directory: /
+    schedule:
+      interval: monthly
+    commit-message:
+      prefix: "build"
+      include: scope
+    groups:
+      gradle-all:
+        patterns:
+          - "*"
+    open-pull-requests-limit: 1
+    labels:
+      - dependencies
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    commit-message:
+      prefix: "ci"
+    groups:
+      actions-all:
+        patterns:
+          - "*"
+    open-pull-requests-limit: 1
+    labels:
+      - dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,31 +1,80 @@
-# Retained for badge/upstream compatibility; CI lives in ci.yml.
+# Badge-compatible workflow; same signed release APK pipeline as ci.yml.
 name: Build and test
 
 on: [push, pull_request]
 
+concurrency:
+  group: build-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
 jobs:
   build:
-    name: Build
+    name: Build signed release APKs
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 60
+    env:
+      RELEASE_KEYSTORE_BASE64: ${{ secrets.RELEASE_KEYSTORE_BASE64 }}
+      RELEASE_KEYSTORE_PASSWORD: ${{ secrets.RELEASE_KEYSTORE_PASSWORD }}
+      RELEASE_KEY_ALIAS: ${{ secrets.RELEASE_KEY_ALIAS }}
+      RELEASE_KEY_PASSWORD: ${{ secrets.RELEASE_KEY_PASSWORD }}
     steps:
       - uses: actions/checkout@v4
+
       - name: Gradle Wrapper Validation
         uses: gradle/actions/wrapper-validation@v4
+
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: 17
           cache: gradle
+
       - uses: android-actions/setup-android@v3
+
       - name: Create local.properties
         run: echo "sdk.dir=${ANDROID_SDK_ROOT}" >> local.properties
-      - name: Build
-        run: ./gradlew check assembleStableDebug compileStableDebugAndroidTestSources --stacktrace --no-daemon
-      - name: Upload APK
+
+      - name: Verify signing secrets
+        run: |
+          missing=0
+          for var in RELEASE_KEYSTORE_BASE64 RELEASE_KEYSTORE_PASSWORD RELEASE_KEY_ALIAS; do
+            if [ -z "${!var}" ]; then
+              echo "::error::$var is not set. CI builds signed release APKs — see README → CI signing."
+              missing=1
+            fi
+          done
+          exit "$missing"
+
+      - name: Unit tests
+        run: ./gradlew check --stacktrace --no-daemon
+
+      - name: Assemble signed stable release APKs (all ABIs)
+        run: ./gradlew :app:assembleStableRelease -PsplitApk --stacktrace --no-daemon
+
+      - name: Verify APK signatures
+        run: |
+          set -euo pipefail
+          APKSIGNER=$(find "${ANDROID_SDK_ROOT}/build-tools" -name apksigner -type f | sort -V | tail -1)
+          found=0
+          shopt -s nullglob
+          for apk in app/build/outputs/apk/stable/release/*-stable-release.apk; do
+            found=1
+            echo "Verifying $apk"
+            "$APKSIGNER" verify --verbose "$apk"
+          done
+          if [ "$found" -eq 0 ]; then
+            echo "::error::No stable release APKs found"
+            ls -laR app/build/outputs/apk || true
+            exit 1
+          fi
+
+      - name: Upload release APKs
         uses: actions/upload-artifact@v4
         with:
-          name: onionshare-${{ github.sha }}-apk
-          path: app/build/outputs/apk/stable/debug/app-stable-debug.apk
+          name: onionshare-stable-release-${{ github.sha }}
+          path: app/build/outputs/apk/stable/release/*-stable-release.apk
           if-no-files-found: error
           retention-days: 14

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,9 +75,10 @@ jobs:
         run: |
           set -euo pipefail
           APKSIGNER=$(find "${ANDROID_SDK_ROOT}/build-tools" -name apksigner -type f | sort -V | tail -1)
+          # AGP names: app-stable-<abi>-release.apk
           found=0
           shopt -s nullglob
-          for apk in app/build/outputs/apk/stable/release/*-stable-release.apk; do
+          for apk in app/build/outputs/apk/stable/release/app-stable-*-release.apk; do
             found=1
             echo "Verifying $apk"
             "$APKSIGNER" verify --verbose "$apk"
@@ -87,11 +88,17 @@ jobs:
             ls -laR app/build/outputs/apk || true
             exit 1
           fi
+          for abi in armeabi-v7a arm64-v8a x86 x86_64; do
+            if [ ! -f "app/build/outputs/apk/stable/release/app-stable-${abi}-release.apk" ]; then
+              echo "::error::Missing ABI APK: ${abi}"
+              exit 1
+            fi
+          done
 
       - name: Upload release APKs
         uses: actions/upload-artifact@v4
         with:
           name: onionshare-stable-release-${{ github.sha }}
-          path: app/build/outputs/apk/stable/release/*-stable-release.apk
+          path: app/build/outputs/apk/stable/release/app-stable-*-release.apk
           if-no-files-found: error
           retention-days: 14

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,6 @@
-# Badge-compatible workflow; same signed release APK pipeline as ci.yml.
-# Signing credentials come only from repository secrets.
+# Badge-compatible workflow (same pipeline as ci.yml).
+# With RELEASE_KEYSTORE_* secrets: signed per-ABI release APKs.
+# Without secrets (e.g. external PRs): check + stable debug (upstream-compatible).
 name: Build and test
 
 on: [push, pull_request]
@@ -13,7 +14,7 @@ permissions:
 
 jobs:
   build:
-    name: Build signed release APKs
+    name: Build
     runs-on: ubuntu-latest
     timeout-minutes: 60
     env:
@@ -38,25 +39,32 @@ jobs:
       - name: Create local.properties
         run: echo "sdk.dir=${ANDROID_SDK_ROOT}" >> local.properties
 
-      - name: Verify GitHub signing secrets
+      - name: Detect signing secrets
+        id: signing
         run: |
           set -euo pipefail
-          missing=0
+          ok=true
           for var in RELEASE_KEYSTORE_BASE64 RELEASE_KEYSTORE_PASSWORD RELEASE_KEY_ALIAS RELEASE_KEY_PASSWORD; do
             val="${!var}"
             if [ -z "$val" ]; then
-              echo "::error::Missing repository secret: $var"
-              missing=1
+              echo "$var: missing"
+              ok=false
             else
               echo "$var: present (${#val} chars)"
             fi
           done
-          exit "$missing"
+          if [ "$ok" = true ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "Signing secrets incomplete — will build stable debug (external PRs / unset secrets)."
+          fi
 
       - name: Unit tests
         run: ./gradlew check --stacktrace --no-daemon
 
       - name: Assemble signed stable release APKs (all ABIs)
+        if: steps.signing.outputs.available == 'true'
         env:
           RELEASE_KEYSTORE_BASE64: ${{ secrets.RELEASE_KEYSTORE_BASE64 }}
           RELEASE_KEYSTORE_PASSWORD: ${{ secrets.RELEASE_KEYSTORE_PASSWORD }}
@@ -72,10 +80,10 @@ jobs:
           fi
 
       - name: Verify APK signatures
+        if: steps.signing.outputs.available == 'true'
         run: |
           set -euo pipefail
           APKSIGNER=$(find "${ANDROID_SDK_ROOT}/build-tools" -name apksigner -type f | sort -V | tail -1)
-          # AGP names: app-stable-<abi>-release.apk
           found=0
           shopt -s nullglob
           for apk in app/build/outputs/apk/stable/release/app-stable-*-release.apk; do
@@ -96,9 +104,23 @@ jobs:
           done
 
       - name: Upload release APKs
+        if: steps.signing.outputs.available == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: onionshare-stable-release-${{ github.sha }}
           path: app/build/outputs/apk/stable/release/app-stable-*-release.apk
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Assemble stable debug (no signing secrets)
+        if: steps.signing.outputs.available != 'true'
+        run: ./gradlew assembleStableDebug compileStableDebugAndroidTestSources --stacktrace --no-daemon
+
+      - name: Upload debug APK
+        if: steps.signing.outputs.available != 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: onionshare-${{ github.sha }}-apk
+          path: app/build/outputs/apk/stable/debug/app-stable-debug.apk
           if-no-files-found: error
           retention-days: 14

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,5 @@
 # Badge-compatible workflow; same signed release APK pipeline as ci.yml.
+# Signing credentials come only from repository secrets.
 name: Build and test
 
 on: [push, pull_request]
@@ -37,13 +38,17 @@ jobs:
       - name: Create local.properties
         run: echo "sdk.dir=${ANDROID_SDK_ROOT}" >> local.properties
 
-      - name: Verify signing secrets
+      - name: Verify GitHub signing secrets
         run: |
+          set -euo pipefail
           missing=0
-          for var in RELEASE_KEYSTORE_BASE64 RELEASE_KEYSTORE_PASSWORD RELEASE_KEY_ALIAS; do
-            if [ -z "${!var}" ]; then
-              echo "::error::$var is not set. CI builds signed release APKs — see README → CI signing."
+          for var in RELEASE_KEYSTORE_BASE64 RELEASE_KEYSTORE_PASSWORD RELEASE_KEY_ALIAS RELEASE_KEY_PASSWORD; do
+            val="${!var}"
+            if [ -z "$val" ]; then
+              echo "::error::Missing repository secret: $var"
               missing=1
+            else
+              echo "$var: present (${#val} chars)"
             fi
           done
           exit "$missing"
@@ -52,7 +57,19 @@ jobs:
         run: ./gradlew check --stacktrace --no-daemon
 
       - name: Assemble signed stable release APKs (all ABIs)
-        run: ./gradlew :app:assembleStableRelease -PsplitApk --stacktrace --no-daemon
+        env:
+          RELEASE_KEYSTORE_BASE64: ${{ secrets.RELEASE_KEYSTORE_BASE64 }}
+          RELEASE_KEYSTORE_PASSWORD: ${{ secrets.RELEASE_KEYSTORE_PASSWORD }}
+          RELEASE_KEY_ALIAS: ${{ secrets.RELEASE_KEY_ALIAS }}
+          RELEASE_KEY_PASSWORD: ${{ secrets.RELEASE_KEY_PASSWORD }}
+        run: |
+          set -euo pipefail
+          ./gradlew :app:assembleStableRelease -PsplitApk --stacktrace --no-daemon \
+            | tee /tmp/gradle-release.log
+          if grep -q 'Release signing skipped' /tmp/gradle-release.log; then
+            echo "::error::Gradle skipped release signing — secrets did not reach the build."
+            exit 1
+          fi
 
       - name: Verify APK signatures
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,31 +1,48 @@
-# Retained for badge/upstream compatibility; CI lives in ci.yml.
-name: Build and test
+name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
 
 jobs:
   build:
-    name: Build
+    name: Build and test
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4
+
       - name: Gradle Wrapper Validation
         uses: gradle/actions/wrapper-validation@v4
+
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: 17
           cache: gradle
+
       - uses: android-actions/setup-android@v3
+
       - name: Create local.properties
         run: echo "sdk.dir=${ANDROID_SDK_ROOT}" >> local.properties
-      - name: Build
+
+      - name: Check and assemble stable debug
         run: ./gradlew check assembleStableDebug compileStableDebugAndroidTestSources --stacktrace --no-daemon
-      - name: Upload APK
+
+      - name: Upload debug APK
         uses: actions/upload-artifact@v4
         with:
-          name: onionshare-${{ github.sha }}-apk
+          name: onionshare-stable-debug-${{ github.sha }}
           path: app/build/outputs/apk/stable/debug/app-stable-debug.apk
           if-no-files-found: error
           retention-days: 14

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,9 +82,10 @@ jobs:
         run: |
           set -euo pipefail
           APKSIGNER=$(find "${ANDROID_SDK_ROOT}/build-tools" -name apksigner -type f | sort -V | tail -1)
+          # AGP names: app-stable-<abi>-release.apk
           found=0
           shopt -s nullglob
-          for apk in app/build/outputs/apk/stable/release/*-stable-release.apk; do
+          for apk in app/build/outputs/apk/stable/release/app-stable-*-release.apk; do
             found=1
             echo "Verifying $apk"
             "$APKSIGNER" verify --verbose "$apk"
@@ -95,7 +96,7 @@ jobs:
             exit 1
           fi
           for abi in armeabi-v7a arm64-v8a x86 x86_64; do
-            if [ ! -f "app/build/outputs/apk/stable/release/app-${abi}-stable-release.apk" ]; then
+            if [ ! -f "app/build/outputs/apk/stable/release/app-stable-${abi}-release.apk" ]; then
               echo "::error::Missing ABI APK: ${abi}"
               exit 1
             fi
@@ -105,6 +106,6 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: onionshare-stable-release-${{ github.sha }}
-          path: app/build/outputs/apk/stable/release/*-stable-release.apk
+          path: app/build/outputs/apk/stable/release/app-stable-*-release.apk
           if-no-files-found: error
           retention-days: 14

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,11 @@
 name: CI
 
+# Builds signed per-ABI stable release APKs (not debug).
+# Requires RELEASE_KEYSTORE_* repository secrets.
+
 on:
   push:
-    branches: [main, master]
+    branches: [main, master, "feat/**"]
   pull_request:
     branches: [main, master]
   workflow_dispatch:
@@ -16,9 +19,14 @@ permissions:
 
 jobs:
   build:
-    name: Build and test
+    name: Build signed release APKs
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 60
+    env:
+      RELEASE_KEYSTORE_BASE64: ${{ secrets.RELEASE_KEYSTORE_BASE64 }}
+      RELEASE_KEYSTORE_PASSWORD: ${{ secrets.RELEASE_KEYSTORE_PASSWORD }}
+      RELEASE_KEY_ALIAS: ${{ secrets.RELEASE_KEY_ALIAS }}
+      RELEASE_KEY_PASSWORD: ${{ secrets.RELEASE_KEY_PASSWORD }}
     steps:
       - uses: actions/checkout@v4
 
@@ -36,13 +44,50 @@ jobs:
       - name: Create local.properties
         run: echo "sdk.dir=${ANDROID_SDK_ROOT}" >> local.properties
 
-      - name: Check and assemble stable debug
-        run: ./gradlew check assembleStableDebug compileStableDebugAndroidTestSources --stacktrace --no-daemon
+      - name: Verify signing secrets
+        run: |
+          missing=0
+          for var in RELEASE_KEYSTORE_BASE64 RELEASE_KEYSTORE_PASSWORD RELEASE_KEY_ALIAS; do
+            if [ -z "${!var}" ]; then
+              echo "::error::$var is not set. CI builds signed release APKs — see README → CI signing."
+              missing=1
+            fi
+          done
+          exit "$missing"
 
-      - name: Upload debug APK
+      - name: Unit tests
+        run: ./gradlew check --stacktrace --no-daemon
+
+      - name: Assemble signed stable release APKs (all ABIs)
+        run: ./gradlew :app:assembleStableRelease -PsplitApk --stacktrace --no-daemon
+
+      - name: Verify APK signatures
+        run: |
+          set -euo pipefail
+          APKSIGNER=$(find "${ANDROID_SDK_ROOT}/build-tools" -name apksigner -type f | sort -V | tail -1)
+          found=0
+          shopt -s nullglob
+          for apk in app/build/outputs/apk/stable/release/*-stable-release.apk; do
+            found=1
+            echo "Verifying $apk"
+            "$APKSIGNER" verify --verbose "$apk"
+          done
+          if [ "$found" -eq 0 ]; then
+            echo "::error::No stable release APKs found"
+            ls -laR app/build/outputs/apk || true
+            exit 1
+          fi
+          for abi in armeabi-v7a arm64-v8a x86 x86_64; do
+            if ! ls app/build/outputs/apk/stable/release/app-${abi}-stable-release.apk >/dev/null 2>&1; then
+              echo "::error::Missing ABI APK: ${abi}"
+              exit 1
+            fi
+          done
+
+      - name: Upload release APKs
         uses: actions/upload-artifact@v4
         with:
-          name: onionshare-stable-debug-${{ github.sha }}
-          path: app/build/outputs/apk/stable/debug/app-stable-debug.apk
+          name: onionshare-stable-release-${{ github.sha }}
+          path: app/build/outputs/apk/stable/release/*-stable-release.apk
           if-no-files-found: error
           retention-days: 14

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,8 @@
 name: CI
 
-# Signed per-ABI stable release APKs from repository secrets only.
-# Required secrets: RELEASE_KEYSTORE_BASE64, RELEASE_KEYSTORE_PASSWORD,
-# RELEASE_KEY_ALIAS, RELEASE_KEY_PASSWORD
+# Same pipeline as build.yml.
+# With RELEASE_KEYSTORE_* secrets: signed per-ABI release APKs.
+# Without secrets (e.g. external PRs): check + stable debug.
 
 on:
   push:
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
   build:
-    name: Build signed release APKs
+    name: Build
     runs-on: ubuntu-latest
     timeout-minutes: 60
     env:
@@ -45,25 +45,32 @@ jobs:
       - name: Create local.properties
         run: echo "sdk.dir=${ANDROID_SDK_ROOT}" >> local.properties
 
-      - name: Verify GitHub signing secrets
+      - name: Detect signing secrets
+        id: signing
         run: |
           set -euo pipefail
-          missing=0
+          ok=true
           for var in RELEASE_KEYSTORE_BASE64 RELEASE_KEYSTORE_PASSWORD RELEASE_KEY_ALIAS RELEASE_KEY_PASSWORD; do
             val="${!var}"
             if [ -z "$val" ]; then
-              echo "::error::Missing repository secret: $var"
-              missing=1
+              echo "$var: missing"
+              ok=false
             else
               echo "$var: present (${#val} chars)"
             fi
           done
-          exit "$missing"
+          if [ "$ok" = true ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "Signing secrets incomplete — will build stable debug (external PRs / unset secrets)."
+          fi
 
       - name: Unit tests
         run: ./gradlew check --stacktrace --no-daemon
 
       - name: Assemble signed stable release APKs (all ABIs)
+        if: steps.signing.outputs.available == 'true'
         env:
           RELEASE_KEYSTORE_BASE64: ${{ secrets.RELEASE_KEYSTORE_BASE64 }}
           RELEASE_KEYSTORE_PASSWORD: ${{ secrets.RELEASE_KEYSTORE_PASSWORD }}
@@ -79,10 +86,10 @@ jobs:
           fi
 
       - name: Verify APK signatures
+        if: steps.signing.outputs.available == 'true'
         run: |
           set -euo pipefail
           APKSIGNER=$(find "${ANDROID_SDK_ROOT}/build-tools" -name apksigner -type f | sort -V | tail -1)
-          # AGP names: app-stable-<abi>-release.apk
           found=0
           shopt -s nullglob
           for apk in app/build/outputs/apk/stable/release/app-stable-*-release.apk; do
@@ -103,9 +110,23 @@ jobs:
           done
 
       - name: Upload release APKs
+        if: steps.signing.outputs.available == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: onionshare-stable-release-${{ github.sha }}
           path: app/build/outputs/apk/stable/release/app-stable-*-release.apk
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Assemble stable debug (no signing secrets)
+        if: steps.signing.outputs.available != 'true'
+        run: ./gradlew assembleStableDebug compileStableDebugAndroidTestSources --stacktrace --no-daemon
+
+      - name: Upload debug APK
+        if: steps.signing.outputs.available != 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: onionshare-${{ github.sha }}-apk
+          path: app/build/outputs/apk/stable/debug/app-stable-debug.apk
           if-no-files-found: error
           retention-days: 14

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,8 @@
 name: CI
 
-# Builds signed per-ABI stable release APKs (not debug).
-# Requires RELEASE_KEYSTORE_* repository secrets.
+# Signed per-ABI stable release APKs from repository secrets only.
+# Required secrets: RELEASE_KEYSTORE_BASE64, RELEASE_KEYSTORE_PASSWORD,
+# RELEASE_KEY_ALIAS, RELEASE_KEY_PASSWORD
 
 on:
   push:
@@ -44,13 +45,17 @@ jobs:
       - name: Create local.properties
         run: echo "sdk.dir=${ANDROID_SDK_ROOT}" >> local.properties
 
-      - name: Verify signing secrets
+      - name: Verify GitHub signing secrets
         run: |
+          set -euo pipefail
           missing=0
-          for var in RELEASE_KEYSTORE_BASE64 RELEASE_KEYSTORE_PASSWORD RELEASE_KEY_ALIAS; do
-            if [ -z "${!var}" ]; then
-              echo "::error::$var is not set. CI builds signed release APKs — see README → CI signing."
+          for var in RELEASE_KEYSTORE_BASE64 RELEASE_KEYSTORE_PASSWORD RELEASE_KEY_ALIAS RELEASE_KEY_PASSWORD; do
+            val="${!var}"
+            if [ -z "$val" ]; then
+              echo "::error::Missing repository secret: $var"
               missing=1
+            else
+              echo "$var: present (${#val} chars)"
             fi
           done
           exit "$missing"
@@ -59,7 +64,19 @@ jobs:
         run: ./gradlew check --stacktrace --no-daemon
 
       - name: Assemble signed stable release APKs (all ABIs)
-        run: ./gradlew :app:assembleStableRelease -PsplitApk --stacktrace --no-daemon
+        env:
+          RELEASE_KEYSTORE_BASE64: ${{ secrets.RELEASE_KEYSTORE_BASE64 }}
+          RELEASE_KEYSTORE_PASSWORD: ${{ secrets.RELEASE_KEYSTORE_PASSWORD }}
+          RELEASE_KEY_ALIAS: ${{ secrets.RELEASE_KEY_ALIAS }}
+          RELEASE_KEY_PASSWORD: ${{ secrets.RELEASE_KEY_PASSWORD }}
+        run: |
+          set -euo pipefail
+          ./gradlew :app:assembleStableRelease -PsplitApk --stacktrace --no-daemon \
+            | tee /tmp/gradle-release.log
+          if grep -q 'Release signing skipped' /tmp/gradle-release.log; then
+            echo "::error::Gradle skipped release signing — secrets did not reach the build."
+            exit 1
+          fi
 
       - name: Verify APK signatures
         run: |
@@ -78,7 +95,7 @@ jobs:
             exit 1
           fi
           for abi in armeabi-v7a arm64-v8a x86 x86_64; do
-            if ! ls app/build/outputs/apk/stable/release/app-${abi}-stable-release.apk >/dev/null 2>&1; then
+            if [ ! -f "app/build/outputs/apk/stable/release/app-${abi}-stable-release.apk" ]; then
               echo "::error::Missing ABI APK: ${abi}"
               exit 1
             fi

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,38 +1,99 @@
 name: Publish nightly build
 
+# Signed nightly release APKs via repository RELEASE_KEYSTORE_* secrets.
+# (Replaces upstream F-Droid DEBUG_KEYSTORE nightly on this fork.)
+
 on:
   push:
     branches:
       - main
+  workflow_dispatch:
+
+concurrency:
+  group: nightly-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
 
 jobs:
   nightly:
-    name: Publish nightly build
+    name: Signed nightly release APKs
     runs-on: ubuntu-latest
-    environment: nightly
+    timeout-minutes: 60
+    env:
+      RELEASE_KEYSTORE_BASE64: ${{ secrets.RELEASE_KEYSTORE_BASE64 }}
+      RELEASE_KEYSTORE_PASSWORD: ${{ secrets.RELEASE_KEYSTORE_PASSWORD }}
+      RELEASE_KEY_ALIAS: ${{ secrets.RELEASE_KEY_ALIAS }}
+      RELEASE_KEY_PASSWORD: ${{ secrets.RELEASE_KEY_PASSWORD }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Gradle dependency cache
-        uses: actions/cache@v3
+      - uses: actions/checkout@v4
+
+      - name: Gradle Wrapper Validation
+        uses: gradle/actions/wrapper-validation@v4
+
+      - uses: actions/setup-java@v4
         with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
-      - name: Set up JDK 11
-        uses: actions/setup-java@v2
+          distribution: temurin
+          java-version: 17
+          cache: gradle
+
+      - uses: android-actions/setup-android@v3
+
+      - name: Create local.properties
+        run: echo "sdk.dir=${ANDROID_SDK_ROOT}" >> local.properties
+
+      - name: Verify GitHub signing secrets
+        run: |
+          set -euo pipefail
+          missing=0
+          for var in RELEASE_KEYSTORE_BASE64 RELEASE_KEYSTORE_PASSWORD RELEASE_KEY_ALIAS RELEASE_KEY_PASSWORD; do
+            val="${!var}"
+            if [ -z "$val" ]; then
+              echo "::error::Missing repository secret: $var"
+              missing=1
+            else
+              echo "$var: present (${#val} chars)"
+            fi
+          done
+          exit "$missing"
+
+      - name: Assemble signed nightly release APKs (all ABIs)
+        env:
+          RELEASE_KEYSTORE_BASE64: ${{ secrets.RELEASE_KEYSTORE_BASE64 }}
+          RELEASE_KEYSTORE_PASSWORD: ${{ secrets.RELEASE_KEYSTORE_PASSWORD }}
+          RELEASE_KEY_ALIAS: ${{ secrets.RELEASE_KEY_ALIAS }}
+          RELEASE_KEY_PASSWORD: ${{ secrets.RELEASE_KEY_PASSWORD }}
+        run: |
+          set -euo pipefail
+          ./gradlew :app:assembleNightlyRelease -PsplitApk --stacktrace --no-daemon \
+            | tee /tmp/gradle-nightly.log
+          if grep -q 'Release signing skipped' /tmp/gradle-nightly.log; then
+            echo "::error::Gradle skipped release signing — secrets did not reach the build."
+            exit 1
+          fi
+
+      - name: Verify APK signatures
+        run: |
+          set -euo pipefail
+          APKSIGNER=$(find "${ANDROID_SDK_ROOT}/build-tools" -name apksigner -type f | sort -V | tail -1)
+          found=0
+          shopt -s nullglob
+          for apk in app/build/outputs/apk/nightly/release/*-nightly-release.apk; do
+            found=1
+            echo "Verifying $apk"
+            "$APKSIGNER" verify --verbose "$apk"
+          done
+          if [ "$found" -eq 0 ]; then
+            echo "::error::No nightly release APKs found"
+            ls -laR app/build/outputs/apk || true
+            exit 1
+          fi
+
+      - name: Upload nightly release APKs
+        uses: actions/upload-artifact@v4
         with:
-          distribution: 'adopt'
-          java-version: 11
-      - name: Build
-        run: ./gradlew assembleNightlyDebug
-      - name: F-Droid nightly builds
-        uses: grote/f-droid-nightly-action@v2
-        with:
-          debug_keystore: ${{ secrets.DEBUG_KEYSTORE }}
-          fdroid_nightly_args: --archive-older 10
-      - name: F-Droid repo permission clean-up # https://github.com/actions/cache/issues/753
-        run: sudo chown -R runner:docker fdroid
+          name: onionshare-nightly-release-${{ github.sha }}
+          path: app/build/outputs/apk/nightly/release/*-nightly-release.apk
+          if-no-files-found: error
+          retention-days: 14

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -77,9 +77,10 @@ jobs:
         run: |
           set -euo pipefail
           APKSIGNER=$(find "${ANDROID_SDK_ROOT}/build-tools" -name apksigner -type f | sort -V | tail -1)
+          # AGP names: app-nightly-<abi>-release.apk
           found=0
           shopt -s nullglob
-          for apk in app/build/outputs/apk/nightly/release/*-nightly-release.apk; do
+          for apk in app/build/outputs/apk/nightly/release/app-nightly-*-release.apk; do
             found=1
             echo "Verifying $apk"
             "$APKSIGNER" verify --verbose "$apk"
@@ -94,6 +95,6 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: onionshare-nightly-release-${{ github.sha }}
-          path: app/build/outputs/apk/nightly/release/*-nightly-release.apk
+          path: app/build/outputs/apk/nightly/release/app-nightly-*-release.apk
           if-no-files-found: error
           retention-days: 14

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,142 @@
+name: Release
+
+# Publishes signed per-ABI stable release APKs to GitHub Releases.
+# ABIs: armeabi-v7a, arm64-v8a, x86, x86_64
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag (e.g. v0.2.3)"
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+
+jobs:
+  release:
+    if: >
+      startsWith(github.ref, 'refs/tags/v') ||
+      (github.event_name == 'workflow_dispatch' && inputs.tag != '')
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      RELEASE_KEYSTORE_BASE64: ${{ secrets.RELEASE_KEYSTORE_BASE64 }}
+      RELEASE_KEYSTORE_PASSWORD: ${{ secrets.RELEASE_KEYSTORE_PASSWORD }}
+      RELEASE_KEY_ALIAS: ${{ secrets.RELEASE_KEY_ALIAS }}
+      RELEASE_KEY_PASSWORD: ${{ secrets.RELEASE_KEY_PASSWORD }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Gradle Wrapper Validation
+        uses: gradle/actions/wrapper-validation@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+          cache: gradle
+
+      - uses: android-actions/setup-android@v3
+
+      - name: Create local.properties
+        run: echo "sdk.dir=${ANDROID_SDK_ROOT}" >> local.properties
+
+      - name: Verify signing secrets
+        run: |
+          missing=0
+          for var in RELEASE_KEYSTORE_BASE64 RELEASE_KEYSTORE_PASSWORD RELEASE_KEY_ALIAS; do
+            if [ -z "${!var}" ]; then
+              echo "::error::$var is not set. See README → CI signing."
+              missing=1
+            fi
+          done
+          exit "$missing"
+
+      - name: Resolve release tag
+        id: meta
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TAG="${{ inputs.tag }}"
+          else
+            TAG="${GITHUB_REF#refs/tags/}"
+          fi
+          VERSION="${TAG#v}"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Assemble signed stable release APKs (all ABIs)
+        run: ./gradlew :app:assembleStableRelease -PsplitApk --stacktrace --no-daemon
+
+      - name: Verify APK signatures
+        run: |
+          set -euo pipefail
+          APKSIGNER=$(find "${ANDROID_SDK_ROOT}/build-tools" -name apksigner -type f | sort -V | tail -1)
+          found=0
+          shopt -s nullglob
+          for apk in app/build/outputs/apk/stable/release/*-stable-release.apk; do
+            found=1
+            echo "Verifying $apk"
+            "$APKSIGNER" verify --verbose "$apk"
+          done
+          if [ "$found" -eq 0 ]; then
+            echo "::error::No stable release APKs found after assembleStableRelease"
+            ls -laR app/build/outputs/apk || true
+            exit 1
+          fi
+
+      - name: Package APKs with checksums
+        run: |
+          set -euo pipefail
+          VERSION="${{ steps.meta.outputs.version }}"
+          mkdir -p dist/release
+          shopt -s nullglob
+          expected_abis=(armeabi-v7a arm64-v8a x86 x86_64)
+          for apk in app/build/outputs/apk/stable/release/*-stable-release.apk; do
+            base=$(basename "$apk")
+            # app-<abi>-stable-release.apk
+            abi=${base#app-}
+            abi=${abi%-stable-release.apk}
+            out="dist/release/onionshare-${VERSION}-${abi}.apk"
+            cp "$apk" "$out"
+            sha256sum "$out" >> dist/release/SHA256SUMS.txt
+            echo "- \`onionshare-${VERSION}-${abi}.apk\` — **${abi}**" >> dist/release/ABI_LIST.md
+          done
+          for abi in "${expected_abis[@]}"; do
+            if [ ! -f "dist/release/onionshare-${VERSION}-${abi}.apk" ]; then
+              echo "::error::Missing ABI APK: ${abi}"
+              exit 1
+            fi
+          done
+          {
+            echo "## OnionShare Android ${VERSION}"
+            echo
+            echo "Signed per-ABI release APKs (\`stable\` flavor)."
+            echo
+            echo "### Assets"
+            cat dist/release/ABI_LIST.md
+            echo
+            echo "Verify: \`sha256sum -c SHA256SUMS.txt\`"
+          } > dist/release/RELEASE_NOTES.md
+          ls -lh dist/release/
+          cat dist/release/SHA256SUMS.txt
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.meta.outputs.tag }}
+          name: OnionShare Android ${{ steps.meta.outputs.version }}
+          generate_release_notes: true
+          prerelease: ${{ contains(steps.meta.outputs.version, 'alpha') || contains(steps.meta.outputs.version, 'beta') || contains(steps.meta.outputs.version, 'rc') }}
+          latest: ${{ !(contains(steps.meta.outputs.version, 'alpha') || contains(steps.meta.outputs.version, 'beta') || contains(steps.meta.outputs.version, 'rc')) }}
+          body_path: dist/release/RELEASE_NOTES.md
+          files: |
+            dist/release/onionshare-*.apk
+            dist/release/SHA256SUMS.txt
+          fail_on_unmatched_files: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,13 +48,17 @@ jobs:
       - name: Create local.properties
         run: echo "sdk.dir=${ANDROID_SDK_ROOT}" >> local.properties
 
-      - name: Verify signing secrets
+      - name: Verify GitHub signing secrets
         run: |
+          set -euo pipefail
           missing=0
-          for var in RELEASE_KEYSTORE_BASE64 RELEASE_KEYSTORE_PASSWORD RELEASE_KEY_ALIAS; do
-            if [ -z "${!var}" ]; then
-              echo "::error::$var is not set. See README → CI signing."
+          for var in RELEASE_KEYSTORE_BASE64 RELEASE_KEYSTORE_PASSWORD RELEASE_KEY_ALIAS RELEASE_KEY_PASSWORD; do
+            val="${!var}"
+            if [ -z "$val" ]; then
+              echo "::error::Missing repository secret: $var"
               missing=1
+            else
+              echo "$var: present (${#val} chars)"
             fi
           done
           exit "$missing"
@@ -72,7 +76,19 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Assemble signed stable release APKs (all ABIs)
-        run: ./gradlew :app:assembleStableRelease -PsplitApk --stacktrace --no-daemon
+        env:
+          RELEASE_KEYSTORE_BASE64: ${{ secrets.RELEASE_KEYSTORE_BASE64 }}
+          RELEASE_KEYSTORE_PASSWORD: ${{ secrets.RELEASE_KEYSTORE_PASSWORD }}
+          RELEASE_KEY_ALIAS: ${{ secrets.RELEASE_KEY_ALIAS }}
+          RELEASE_KEY_PASSWORD: ${{ secrets.RELEASE_KEY_PASSWORD }}
+        run: |
+          set -euo pipefail
+          ./gradlew :app:assembleStableRelease -PsplitApk --stacktrace --no-daemon \
+            | tee /tmp/gradle-release.log
+          if grep -q 'Release signing skipped' /tmp/gradle-release.log; then
+            echo "::error::Gradle skipped release signing — secrets did not reach the build."
+            exit 1
+          fi
 
       - name: Verify APK signatures
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,7 +122,6 @@ jobs:
             abi=${abi%-release.apk}
             out="dist/release/onionshare-${VERSION}-${abi}.apk"
             cp "$apk" "$out"
-            sha256sum "$out" >> dist/release/SHA256SUMS.txt
             echo "- \`onionshare-${VERSION}-${abi}.apk\` — **${abi}**" >> dist/release/ABI_LIST.md
           done
           for abi in "${expected_abis[@]}"; do
@@ -131,6 +130,8 @@ jobs:
               exit 1
             fi
           done
+          # Basename paths so `sha256sum -c` works after downloading assets flat.
+          (cd dist/release && sha256sum onionshare-*.apk > SHA256SUMS.txt)
           {
             echo "## OnionShare Android ${VERSION}"
             echo
@@ -140,6 +141,8 @@ jobs:
             cat dist/release/ABI_LIST.md
             echo
             echo "Verify: \`sha256sum -c SHA256SUMS.txt\`"
+            echo
+            echo "Phones: prefer **arm64-v8a**. Obtainium APK filter: \`arm64-v8a\`."
           } > dist/release/RELEASE_NOTES.md
           ls -lh dist/release/
           cat dist/release/SHA256SUMS.txt
@@ -150,10 +153,14 @@ jobs:
           tag_name: ${{ steps.meta.outputs.tag }}
           name: OnionShare Android ${{ steps.meta.outputs.version }}
           generate_release_notes: true
-          prerelease: ${{ contains(steps.meta.outputs.version, 'alpha') || contains(steps.meta.outputs.version, 'beta') || contains(steps.meta.outputs.version, 'rc') }}
-          latest: ${{ !(contains(steps.meta.outputs.version, 'alpha') || contains(steps.meta.outputs.version, 'beta') || contains(steps.meta.outputs.version, 'rc')) }}
+          # Do NOT set GitHub "prerelease": GitHub forbids make_latest on
+          # prereleases, so /releases/latest 404s and Obtainium breaks. The APK
+          # versionName may still contain -beta; only the GitHub flag is off.
+          prerelease: false
+          make_latest: true
           body_path: dist/release/RELEASE_NOTES.md
           files: |
             dist/release/onionshare-*.apk
             dist/release/SHA256SUMS.txt
           fail_on_unmatched_files: true
+          overwrite_files: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,9 +94,10 @@ jobs:
         run: |
           set -euo pipefail
           APKSIGNER=$(find "${ANDROID_SDK_ROOT}/build-tools" -name apksigner -type f | sort -V | tail -1)
+          # AGP names: app-stable-<abi>-release.apk
           found=0
           shopt -s nullglob
-          for apk in app/build/outputs/apk/stable/release/*-stable-release.apk; do
+          for apk in app/build/outputs/apk/stable/release/app-stable-*-release.apk; do
             found=1
             echo "Verifying $apk"
             "$APKSIGNER" verify --verbose "$apk"
@@ -114,11 +115,11 @@ jobs:
           mkdir -p dist/release
           shopt -s nullglob
           expected_abis=(armeabi-v7a arm64-v8a x86 x86_64)
-          for apk in app/build/outputs/apk/stable/release/*-stable-release.apk; do
+          for apk in app/build/outputs/apk/stable/release/app-stable-*-release.apk; do
             base=$(basename "$apk")
-            # app-<abi>-stable-release.apk
-            abi=${base#app-}
-            abi=${abi%-stable-release.apk}
+            # app-stable-<abi>-release.apk
+            abi=${base#app-stable-}
+            abi=${abi%-release.apk}
             out="dist/release/onionshare-${VERSION}-${abi}.apk"
             cp "$apk" "$out"
             sha256sum "$out" >> dist/release/SHA256SUMS.txt

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,9 @@
 local.properties
 /Gemfile.lock
 /.bundle/config
+
+# Release signing (never commit)
+keystore.properties
+*.jks
+*.keystore
+!keystore.properties.example

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Release APKs are produced for `armeabi-v7a`, `arm64-v8a`, `x86`, and `x86_64`.
 
 ## CI signing
 
+CI (`build.yml` / `ci.yml`) and Release both assemble **signed** per-ABI `stable` release APKs (not debug). Secrets are required on every CI run.
+
 Release keystores are provided only via GitHub Actions secrets. Never commit `keystore.properties` or `.jks` / `.keystore` files.
 
 | Secret | Description |

--- a/README.md
+++ b/README.md
@@ -50,3 +50,7 @@ Locally: copy `keystore.properties.example` → `keystore.properties` (gitignore
 Push a tag `v*.*.*` (for example `v0.2.3-beta`) or run **Actions → Release → Run workflow**
 with a tag. The workflow builds signed per-ABI `stable` APKs and uploads them to a
 GitHub Release with `SHA256SUMS.txt`.
+
+Releases are marked **Latest** (GitHub `prerelease=false`) so `GET /releases/latest`
+works for Obtainium and similar clients. The APK `versionName` may still contain
+`-beta`; only the GitHub prerelease flag stays off.

--- a/README.md
+++ b/README.md
@@ -21,16 +21,16 @@ Release APKs are produced for `armeabi-v7a`, `arm64-v8a`, `x86`, and `x86_64`.
 
 ## CI signing
 
-CI (`build.yml` / `ci.yml`) and Release both assemble **signed** per-ABI `stable` release APKs (not debug). Secrets are required on every CI run.
+CI (`build.yml` / `ci.yml`), Nightly, and Release all assemble **signed** per-ABI release APKs (not debug). Credentials are injected only from **repository secrets** (`${{ secrets.* }}` → env → Gradle). Builds fail if any secret is missing or if Gradle reports “Release signing skipped”.
 
-Release keystores are provided only via GitHub Actions secrets. Never commit `keystore.properties` or `.jks` / `.keystore` files.
+Never commit `keystore.properties` or `.jks` / `.keystore` files.
 
 | Secret | Description |
 | --- | --- |
 | `RELEASE_KEYSTORE_BASE64` | Base64-encoded `.jks` / `.keystore` |
 | `RELEASE_KEYSTORE_PASSWORD` | Keystore password |
-| `RELEASE_KEY_ALIAS` | Key alias (default example: `onionshare`) |
-| `RELEASE_KEY_PASSWORD` | Key password (defaults to keystore password if omitted locally) |
+| `RELEASE_KEY_ALIAS` | Key alias (`onionshare`) |
+| `RELEASE_KEY_PASSWORD` | Key password |
 
 Generate a keystore and print the `gh secret set` commands:
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,43 @@
 # OnionShare for Android
 
-[![Build](https://github.com/onionshare/onionshare-android/actions/workflows/build.yml/badge.svg)](https://github.com/onionshare/onionshare-android/actions/workflows/build.yml)
+[![Build](https://github.com/LTechnologies0/onionshare-android/actions/workflows/build.yml/badge.svg)](https://github.com/LTechnologies0/onionshare-android/actions/workflows/build.yml)
+[![CI](https://github.com/LTechnologies0/onionshare-android/actions/workflows/ci.yml/badge.svg)](https://github.com/LTechnologies0/onionshare-android/actions/workflows/ci.yml)
+[![Release](https://github.com/LTechnologies0/onionshare-android/actions/workflows/release.yml/badge.svg)](https://github.com/LTechnologies0/onionshare-android/actions/workflows/release.yml)
 
-Android version of OnionShare
+Android version of OnionShare (fork of [onionshare/onionshare-android](https://github.com/onionshare/onionshare-android)).
 
-It
-was [audited by Radically Open Security](https://github.com/onionshare/onionshare-android/blob/main/docs/report_onionshare-android.pdf)
-on June 30th, 2023.
+It was [audited by Radically Open Security](docs/report_onionshare-android.pdf) on June 30th, 2023.
 All found issues have since been resolved.
+
+## Build
+
+```bash
+./gradlew assembleStableDebug
+# Signed per-ABI stable release (requires keystore — see below):
+./gradlew assembleStableRelease -PsplitApk
+```
+
+Release APKs are produced for `armeabi-v7a`, `arm64-v8a`, `x86`, and `x86_64`.
+
+## CI signing
+
+Release keystores are provided only via GitHub Actions secrets. Never commit `keystore.properties` or `.jks` / `.keystore` files.
+
+| Secret | Description |
+| --- | --- |
+| `RELEASE_KEYSTORE_BASE64` | Base64-encoded `.jks` / `.keystore` |
+| `RELEASE_KEYSTORE_PASSWORD` | Keystore password |
+| `RELEASE_KEY_ALIAS` | Key alias (default example: `onionshare`) |
+| `RELEASE_KEY_PASSWORD` | Key password (defaults to keystore password if omitted locally) |
+
+Generate a keystore and print the `gh secret set` commands:
+
+```bash
+bash scripts/generate-release-keystore.sh
+```
+
+Locally: copy `keystore.properties.example` → `keystore.properties` (gitignored).
+
+### Publish a release
+
+Push a tag `v*.*.*` or run **Actions → Release → Run workflow** with a tag (e.g. `v0.2.3`). The workflow builds signed per-ABI `stable` APKs and uploads them to a GitHub Release with `SHA256SUMS.txt`.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
 # OnionShare for Android
 
-[![Build](https://github.com/LTechnologies0/onionshare-android/actions/workflows/build.yml/badge.svg)](https://github.com/LTechnologies0/onionshare-android/actions/workflows/build.yml)
-[![CI](https://github.com/LTechnologies0/onionshare-android/actions/workflows/ci.yml/badge.svg)](https://github.com/LTechnologies0/onionshare-android/actions/workflows/ci.yml)
-[![Release](https://github.com/LTechnologies0/onionshare-android/actions/workflows/release.yml/badge.svg)](https://github.com/LTechnologies0/onionshare-android/actions/workflows/release.yml)
+[![Build](https://github.com/onionshare/onionshare-android/actions/workflows/build.yml/badge.svg)](https://github.com/onionshare/onionshare-android/actions/workflows/build.yml)
 
-Android version of OnionShare (fork of [onionshare/onionshare-android](https://github.com/onionshare/onionshare-android)).
+Android version of OnionShare.
 
 It was [audited by Radically Open Security](docs/report_onionshare-android.pdf) on June 30th, 2023.
 All found issues have since been resolved.
@@ -17,11 +15,18 @@ All found issues have since been resolved.
 ./gradlew assembleStableRelease -PsplitApk
 ```
 
-Release APKs are produced for `armeabi-v7a`, `arm64-v8a`, `x86`, and `x86_64`.
+With `-PsplitApk`, release APKs are produced for `armeabi-v7a`, `arm64-v8a`, `x86`, and `x86_64`.
 
-## CI signing
+## CI signing and releases
 
-CI (`build.yml` / `ci.yml`), Nightly, and Release all assemble **signed** per-ABI release APKs (not debug). Credentials are injected only from **repository secrets** (`${{ secrets.* }}` → env → Gradle). Builds fail if any secret is missing or if Gradle reports “Release signing skipped”.
+CI (`build.yml` / `ci.yml`) runs unit tests always. When repository
+`RELEASE_KEYSTORE_*` secrets are present, it also builds **signed** per-ABI
+stable release APKs and verifies signatures. Without secrets (typical for
+external pull requests), CI falls back to `assembleStableDebug` so contributors
+are not blocked.
+
+Nightly and the Release workflow always require signing secrets and fail if they
+are missing or if Gradle reports “Release signing skipped”.
 
 Never commit `keystore.properties` or `.jks` / `.keystore` files.
 
@@ -42,4 +47,6 @@ Locally: copy `keystore.properties.example` → `keystore.properties` (gitignore
 
 ### Publish a release
 
-Push a tag `v*.*.*` or run **Actions → Release → Run workflow** with a tag (e.g. `v0.2.3`). The workflow builds signed per-ABI `stable` APKs and uploads them to a GitHub Release with `SHA256SUMS.txt`.
+Push a tag `v*.*.*` (for example `v0.2.3-beta`) or run **Actions → Release → Run workflow**
+with a tag. The workflow builds signed per-ABI `stable` APKs and uploads them to a
+GitHub Release with `SHA256SUMS.txt`.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -69,8 +69,13 @@ android {
     }
     splits {
         abi {
-            // can not be defined per flavor, so we use a property to turn this on for F-Droid
-            enable project.hasProperty('splitApk')
+            // Per-ABI APKs for F-Droid (-PsplitApk) and GitHub release builds.
+            // Debug stays as a single universal APK for faster local installs.
+            def isReleaseTask = gradle.startParameter.taskNames.any {
+                def n = it.toString().toLowerCase()
+                n.contains("release") && !n.contains("debug")
+            }
+            enable project.hasProperty('splitApk') || isReleaseTask
             reset() // Resets the list of ABIs to remove all included by default
             include "armeabi-v7a", "arm64-v8a", "x86", "x86_64"
             universalApk false
@@ -205,3 +210,4 @@ tasks.register('unpackTorBinaries') {
 preBuild.dependsOn unpackTorBinaries
 
 apply from: "${rootProject.rootDir}/gradle/ktlint.gradle"
+apply from: "${rootProject.rootDir}/gradle/release-signing.gradle"

--- a/gradle/release-signing.gradle
+++ b/gradle/release-signing.gradle
@@ -1,0 +1,71 @@
+// Release signing: local keystore.properties or CI environment variables.
+// Never commit keystore.properties — copy from keystore.properties.example.
+
+import java.util.Base64
+
+def signingPropsFile = rootProject.file("keystore.properties")
+def keystorePath = System.getenv("RELEASE_KEYSTORE_PATH")
+def keystoreB64 = System.getenv("RELEASE_KEYSTORE_BASE64")
+
+def resolveKeystoreFile = {
+    if (keystorePath != null && !keystorePath.isBlank()) {
+        def f = rootProject.file(keystorePath)
+        return f.exists() ? f : null
+    }
+    if (keystoreB64 != null && !keystoreB64.isBlank()) {
+        def decoded = rootProject.file("${rootProject.buildDir}/ci-release.keystore")
+        decoded.parentFile.mkdirs()
+        decoded.bytes = Base64.decoder.decode(keystoreB64)
+        return decoded
+    }
+    if (signingPropsFile.exists()) {
+        def props = new Properties()
+        signingPropsFile.withInputStream { props.load(it) }
+        def storePath = props.getProperty("storeFile")
+        if (storePath != null) {
+            def f = rootProject.file(storePath)
+            return f.exists() ? f : null
+        }
+    }
+    return null
+}
+
+def resolveCredential = { String propKey, String envKey, Properties props ->
+    def fromEnv = System.getenv(envKey)
+    if (fromEnv != null && !fromEnv.isBlank()) return fromEnv
+    return props?.getProperty(propKey)
+}
+
+def keystoreFile = resolveKeystoreFile()
+if (keystoreFile == null) {
+    logger.lifecycle("Release signing skipped: no keystore (keystore.properties or RELEASE_KEYSTORE_* env).")
+} else {
+    def props = signingPropsFile.exists() ? new Properties().with { p ->
+        signingPropsFile.withInputStream { p.load(it) }
+        p
+    } : null
+
+    def storePasswordValue = resolveCredential("storePassword", "RELEASE_KEYSTORE_PASSWORD", props)
+    def keyAliasValue = resolveCredential("keyAlias", "RELEASE_KEY_ALIAS", props) ?: "onionshare"
+    def keyPasswordValue = resolveCredential("keyPassword", "RELEASE_KEY_PASSWORD", props) ?: storePasswordValue
+
+    if (storePasswordValue == null) {
+        logger.warn("Release keystore found but store password missing; APK will be unsigned.")
+    } else {
+        android {
+            signingConfigs {
+                release {
+                    storeFile keystoreFile
+                    storePassword storePasswordValue
+                    keyAlias keyAliasValue
+                    keyPassword keyPasswordValue
+                }
+            }
+            buildTypes {
+                release {
+                    signingConfig signingConfigs.release
+                }
+            }
+        }
+    }
+}

--- a/keystore.properties.example
+++ b/keystore.properties.example
@@ -1,0 +1,7 @@
+# Copy to keystore.properties (gitignored) for local release signing.
+# Never commit keystore.properties or the keystore file.
+
+storeFile=release.keystore
+storePassword=
+keyAlias=onionshare
+keyPassword=

--- a/scripts/generate-release-keystore.sh
+++ b/scripts/generate-release-keystore.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Generate a release keystore for local signing or CI secret setup.
+# NEVER commit the generated keystore or passwords to git.
+
+set -euo pipefail
+
+KEYSTORE="${1:-release.keystore}"
+ALIAS="${2:-onionshare}"
+VALIDITY_DAYS="${3:-10000}"
+
+if [[ -f "$KEYSTORE" ]]; then
+  echo "ERROR: $KEYSTORE already exists. Remove it first or choose another path."
+  exit 1
+fi
+
+if [[ -z "${KEYSTORE_PASSWORD:-}" ]]; then
+  KEYSTORE_PASSWORD="$(openssl rand -base64 32 | tr -d '\n=/+' | head -c 32)"
+fi
+
+keytool -genkeypair \
+  -v \
+  -keystore "$KEYSTORE" \
+  -alias "$ALIAS" \
+  -keyalg RSA \
+  -keysize 3072 \
+  -validity "$VALIDITY_DAYS" \
+  -storepass "$KEYSTORE_PASSWORD" \
+  -keypass "$KEYSTORE_PASSWORD" \
+  -dname "CN=OnionShare Android, OU=OnionPhone, O=LTechnologies, C=FR"
+
+echo ""
+echo "Keystore created: $KEYSTORE"
+echo ""
+echo "Local signing — copy keystore.properties.example to keystore.properties:"
+echo "  storeFile=$KEYSTORE"
+echo "  storePassword=$KEYSTORE_PASSWORD"
+echo "  keyAlias=$ALIAS"
+echo "  keyPassword=$KEYSTORE_PASSWORD"
+echo ""
+echo "CI signing — set GitHub secrets (from repo root):"
+echo "  gh secret set RELEASE_KEYSTORE_BASE64 < <(base64 -w0 \"$KEYSTORE\" 2>/dev/null || base64 <\"$KEYSTORE\" | tr -d '\\n')"
+echo "  gh secret set RELEASE_KEYSTORE_PASSWORD --body \"$KEYSTORE_PASSWORD\""
+echo "  gh secret set RELEASE_KEY_ALIAS --body \"$ALIAS\""
+echo "  gh secret set RELEASE_KEY_PASSWORD --body \"$KEYSTORE_PASSWORD\""


### PR DESCRIPTION
## Summary

Adds a release-signing pipeline so maintainers can publish **signed, per-ABI** stable APKs from GitHub Actions (and optionally from local builds) without committing keystore material.

- **Release workflow** (`release.yml`): on tag `v*.*.*` (or manual dispatch), assemble `assembleStableRelease -PsplitApk`, verify with `apksigner`, upload `onionshare-<version>-<abi>.apk` plus `SHA256SUMS.txt`.
- **Gradle signing** (`gradle/release-signing.gradle`): reads `RELEASE_KEYSTORE_*` env (CI) or local `keystore.properties`; never commits secrets.
- **ABI splits**: `armeabi-v7a`, `arm64-v8a`, `x86`, `x86_64` (AGP `app-stable-<abi>-release.apk` naming).
- **CI / Build**: with secrets → signed release artifacts; **without secrets** (external PRs) → `check` + `assembleStableDebug` so contributors are not blocked.
- **Nightly**: signed nightlies when secrets are configured (replaces debug-keystore nightlies on forks that set secrets).
- **Dependabot**: monthly Gradle + Actions updates.
- **Docs / helpers**: README CI table, `keystore.properties.example`, `scripts/generate-release-keystore.sh`.

## Motivation

Upstream CI currently builds and uploads a single **debug** APK. For distribution outside F-Droid (GitHub Releases, Obtainium, direct install), projects need reproducible **release-signed** per-ABI artifacts with checksums, while keeping keystores only in repository secrets.

## Secrets required (maintainers)

| Secret | Purpose |
| --- | --- |
| `RELEASE_KEYSTORE_BASE64` | Base64-encoded keystore |
| `RELEASE_KEYSTORE_PASSWORD` | Keystore password |
| `RELEASE_KEY_ALIAS` | Key alias |
| `RELEASE_KEY_PASSWORD` | Key password |

Until these are set on `onionshare/onionshare-android`, PR CI will take the **debug fallback** path (same contributor experience as today). Release/Nightly jobs that require signing will fail until secrets exist — intentional fail-closed for publish paths.

## Test plan

- [ ] Open this PR: Build/CI should pass via debug fallback if upstream has no signing secrets yet
- [ ] On a fork/repo with `RELEASE_KEYSTORE_*` set: push to a branch and confirm signed `app-stable-*-release.apk` artifacts upload
- [ ] Tag `v0.2.3-beta` (or dispatch Release) and confirm four ABI APKs + `SHA256SUMS.txt` on the GitHub Release
- [ ] `apksigner verify` on each uploaded APK
- [ ] Local: `keystore.properties` from example → `./gradlew assembleStableRelease -PsplitApk`